### PR TITLE
Add support for _TZ3000_f2slq5pj (TS0012) aka Bseed 2 Gang touch panel, no neutral

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -173,6 +173,18 @@ MOES_2_GANG_SWITCH_END_DEVICE:
   human_name: Moes TS0012 (2 gang switch)
   status: In progress
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
+BSEED_2_GANG_SWITCH_END_DEVICE:
+  name: Bseed-2-gang
+  config_str: Bseed-2-gang;Bseed-2-gang-ED;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
+  device_type: end_device
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 43510
+  tuya_converter_model: TS0012
+  tuya_manufacturer_names:
+      - _TZ3000_f2slq5pj
+  human_name: Bseed TS0012 (2 gang switch)
+  status: Supported
 TS0012_AVATTO:
   name: TS0012-custom
   config_str: TS0012-Avatto;TS0012-avatto;BB4f;LB5;SC0f;SC3f;RC2;RC4;

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ Note that rebranded versions may have different internals and may not work. "Zig
 | [TS0002_limited](https://www.zigbee2mqtt.io/devices/TS0002_limited.html) | Avatto TS0002  | _TZ3000_mtnpt6ws | router | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/9)  | 
 | [TS0004_switch_module_2](https://www.zigbee2mqtt.io/devices/TS0004_switch_module_2.html) | Avatto TS0004  | _TZ3000_5ajpkyq6 | router | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/9)  | 
 | [TS0012](https://www.zigbee2mqtt.io/devices/TS0012.html) | Moes TS0012 (2 gang switch)  | _TZ3000_18ejxno0 | router / end_device | In progress |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/14)  | 
+| [TS0012](https://www.zigbee2mqtt.io/devices/TS0012.html) | Bseed TS0012 (2 gang switch)  | _TZ3000_f2slq5pj | end_device | Supported |   -  | 
 | [TS0012_switch_module](https://www.zigbee2mqtt.io/devices/TS0012_switch_module.html) | Avatto TS0012  | _TZ3000_ljhbw1c9 | router / end_device | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/16)  | 
 | [WHD02](https://www.zigbee2mqtt.io/devices/WHD02.html) | Aubess WHD02  | _TZ3000_46t1rvdu | router / end_device | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/18)  | 
 

--- a/zigbee2mqtt/converters/switch_custom.js
+++ b/zigbee2mqtt/converters/switch_custom.js
@@ -673,6 +673,53 @@ const definitions = [
     },
     {
         zigbeeModel: [
+            "Bseed-2-gang-ED",
+        ],
+        model: "Bseed-2-gang",
+        vendor: "Tuya-custom",
+        description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
+        extend: [
+            deviceEndpoints({ endpoints: {1: 1, 2: 2, "left": 3, "right": 4, } }),
+            romasku.deviceConfig("device_config", "1"),
+            onOff({ endpointNames: ["left", "right"] }),
+            romasku.pressAction("switch_1_press_action", "1"),
+            romasku.switchMode("switch_1_mode", "1"),
+            romasku.switchAction("switch_1_action_mode", "1"),
+            romasku.relayMode("switch_1_relay_mode", "1"),
+            romasku.relayIndex("switch_1_relay_index", "1", 2),
+            romasku.longPressDuration("switch_1_long_press_duration", "1"),
+            romasku.pressAction("switch_2_press_action", "2"),
+            romasku.switchMode("switch_2_mode", "2"),
+            romasku.switchAction("switch_2_action_mode", "2"),
+            romasku.relayMode("switch_2_relay_mode", "2"),
+            romasku.relayIndex("switch_2_relay_index", "2", 2),
+            romasku.longPressDuration("switch_2_long_press_duration", "2"),
+            romasku.relayIndicatorMode("relay_left_indicator_mode", "left"),
+            romasku.relayIndicator("relay_left_indicator", "left"),
+            romasku.relayIndicatorMode("relay_right_indicator_mode", "right"),
+            romasku.relayIndicator("relay_right_indicator", "right"),
+        ],
+        meta: { multiEndpoint: true },
+        configure: async (device, coordinatorEndpoint, logger) => {
+            await reporting.bind(device.getEndpoint(1), coordinatorEndpoint, ["genMultistateInput"]);
+            await reporting.bind(device.getEndpoint(2), coordinatorEndpoint, ["genMultistateInput"]);
+            const endpoint3 = device.getEndpoint(3);
+            await reporting.onOff(endpoint3, {
+                min: 0,
+                max: constants.repInterval.MINUTE,
+                change: 1,
+            });
+            const endpoint4 = device.getEndpoint(4);
+            await reporting.onOff(endpoint4, {
+                min: 0,
+                max: constants.repInterval.MINUTE,
+                change: 1,
+            });
+        },
+        ota: true,
+    },
+    {
+        zigbeeModel: [
             "TS0012-avatto",
         ],
         model: "TS0012-custom",

--- a/zigbee2mqtt/ota/index_end_device-FORCE.json
+++ b/zigbee2mqtt/ota/index_end_device-FORCE.json
@@ -10,7 +10,22 @@
     "otaHeaderString": "Telink Zigbee OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
     "manufacturerName": [
       "_TZ3000_18ejxno0",
-      "Moes-2-gang"
+      "Moes-2-gang",
+      "_TZ3000_f2slq5pj"
+    ]
+  },
+  {
+    "fileName": "1141-a9f6-ffffffff-tlc_switch-forced.zigbee",
+    "fileVersion": 4294967295,
+    "fileSize": 126338,
+    "url": "https://github.com/romasku/tuya-zigbee-switch/raw/223f446ca6fa5242f98496686ba39cf78aa25a85/bin/MOES_2_GANG_SWITCH_END_DEVICE/1141-a9f6-ffffffff-tlc_switch-forced.zigbee",
+    "imageType": 43510,
+    "manufacturerCode": 4417,
+    "sha512": "f2ebd39d9b441674a34880a52abf2787d62e113c72219537caf291b4757e5938c6810365d02e410db5a9f7c47fae4eb77fc3243db218140297b0d8b072ff881b",
+    "otaHeaderString": "Telink Zigbee OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "manufacturerName": [
+      "Bseed-2-gang",
+      "_TZ3000_f2slq5pj"
     ]
   },
   {

--- a/zigbee2mqtt/ota/index_end_device.json
+++ b/zigbee2mqtt/ota/index_end_device.json
@@ -10,7 +10,8 @@
     "otaHeaderString": "Telink Zigbee OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
     "manufacturerName": [
       "_TZ3000_18ejxno0",
-      "Moes-2-gang"
+      "Moes-2-gang",
+      "_TZ3000_f2slq5pj"
     ]
   },
   {
@@ -24,7 +25,8 @@
     "otaHeaderString": "Telink Zigbee OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
     "manufacturerName": [
       "_TZ3000_18ejxno0",
-      "Moes-2-gang"
+      "Moes-2-gang",
+      "_TZ3000_f2slq5pj"
     ]
   },
   {

--- a/zigbee2mqtt/ota/index_end_device.json
+++ b/zigbee2mqtt/ota/index_end_device.json
@@ -30,6 +30,34 @@
     ]
   },
   {
+    "fileName": "1141-a9f6-01033008-tlc_switch.zigbee",
+    "fileVersion": 16986120,
+    "fileSize": 126338,
+    "url": "https://github.com/romasku/tuya-zigbee-switch/raw/223f446ca6fa5242f98496686ba39cf78aa25a85/bin/MOES_2_GANG_SWITCH_END_DEVICE/1141-a9f6-01033008-tlc_switch.zigbee",
+    "imageType": 43510,
+    "manufacturerCode": 4417,
+    "sha512": "6ef2a7de54f04f19025f97f1771e0b0e8373f241fa39ba0a6bc8c075be5826b4eda4e4fb08a5c2959cb3c32be568ee7937368cc278f6ac56be081eebd867b107",
+    "otaHeaderString": "Telink Zigbee OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "manufacturerName": [
+      "Bseed-2-gang",
+      "_TZ3000_f2slq5pj"
+    ]
+  },
+  {
+    "fileName": "1141-d3a3-ffffffff-tlc_switch-from_tuya.zigbee",
+    "fileVersion": 4294967295,
+    "fileSize": 126338,
+    "url": "https://github.com/romasku/tuya-zigbee-switch/raw/223f446ca6fa5242f98496686ba39cf78aa25a85/bin/MOES_2_GANG_SWITCH_END_DEVICE/1141-d3a3-ffffffff-tlc_switch-from_tuya.zigbee",
+    "imageType": 54179,
+    "manufacturerCode": 4417,
+    "sha512": "f89f15c12d04fc77b69f1e49fa7dd6de8215555b49048c38f99709c292d85358931d3d3f1d5c943fa70ed80c655dab366d54c99a5c11f211e6865c9521288732",
+    "otaHeaderString": "Telink Zigbee OTA\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000",
+    "manufacturerName": [
+      "Bseed-2-gang",
+      "_TZ3000_f2slq5pj"
+    ]
+  },
+  {
     "fileName": "1141-aa04-01033008-tlc_switch.zigbee",
     "fileVersion": 16986120,
     "fileSize": 126322,


### PR DESCRIPTION
Switch is based on the ZTU module. Firmware is the same as Moes 2 Gang ED, but the pinout is different:
`Bseed-2-gang;Bseed-2-gang-ED;SB6u;SA1u;RD3;RC0;IC2;IB4;M;`

Already tested the firmware with the modified pinout - everything seems to work fine. Also there is a hardware possibility to fully disable both LEDs by using pin `C3`, but it needs to be implemented in software