### PR TITLE
Add Moes MS-104CZ (Tuya TS0003) support

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -370,3 +370,16 @@ TS0011_AVATTO_END_DEVICE:
   human_name: Avatto TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
+TS0003:
+  name: TS0003-custom
+  config_str: Tuya-TS0003-custom;TS0003-custom;BD3u;SC1u;SD7u;SC3u;RB5;RD4;RB4;
+  device_type: router
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 43538
+  stock_converter_model: TS0003
+  tuya_manufacturer_names:
+    - _TZ3000_pfc7i3kt
+  human_name: Moes MS-104CZ
+  status: Supported
+  github_issue:

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,7 @@ Note that rebranded versions may have different internals and may not work. "Zig
 | [TS0002_basic](https://www.zigbee2mqtt.io/devices/TS0002_basic.html) | No name TS0002  | _TZ3000_zmy4lslw | router | Not working, pinout is not correct |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/29)  | 
 | [TS0001_switch_module](https://www.zigbee2mqtt.io/devices/TS0001_switch_module.html) | Avatto TS0001  | _TZ3000_4rbqgcuv | router | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/9)  | 
 | [TS0002_limited](https://www.zigbee2mqtt.io/devices/TS0002_limited.html) | Avatto TS0002  | _TZ3000_mtnpt6ws | router | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/9)  | 
+| [TS0003](https://www.zigbee2mqtt.io/devices/TS0003.html) | Moes MS-104CZ  | _TZ3000_pfc7i3kt | router | Supported |    -  |
 | [TS0004_switch_module_2](https://www.zigbee2mqtt.io/devices/TS0004_switch_module_2.html) | Avatto TS0004  | _TZ3000_5ajpkyq6 | router | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/9)  | 
 | [TS0012](https://www.zigbee2mqtt.io/devices/TS0012.html) | Moes TS0012 (2 gang switch)  | _TZ3000_18ejxno0 | router / end_device | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/issues/14)  | 
 | [TS0012](https://www.zigbee2mqtt.io/devices/TS0012.html) | Bseed TS0012 (2 gang switch)  | _TZ3000_f2slq5pj | router / end_device | Supported |   [link](https://github.com/romasku/tuya-zigbee-switch/pull/23)  | 


### PR DESCRIPTION
Added the device above - it's a 3-way switch module, neutral required, Aliexpress link: https://www.aliexpress.com/item/1005004986958450.html
Correct pic is here, Z2M just shows generic TUYA logo: https://user-images.githubusercontent.com/14648014/210105595-7cf007dd-ee0f-4cfd-82ca-79acf3268764.png
Note that this module has a buzzer on pin C2 (used on stock FW for indicating when it's in pairing mode) but it needs to be driven at ~3kHz to work and I didn't dig enough into your code to work out how to drive it. No indicator LEDs.