### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y make python3 python3-pip
+        sudo apt-get install -y make python3 python3-pip unzip wget
         python3 -m pip install --upgrade pip
         pip install yq jinja2
 


### PR DESCRIPTION
The build workflow takes for granted unzip and wget.
Which is fair! They are preinstalled on the GitHub runner.

But I tried to build the firmware on WSL and it took me so long to figure out I was missing unzip!
If the packages were there I would not have run into that issue because I copy-pasted that line.

I think adding them makes it foolproof.