### PR TITLE
Automatically get repo link and branch name for OTA index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,7 @@ update_readme:
 
 
 freeze_ota_links:
-	sed -i "s/refs\/heads\/main/$(shell git rev-parse HEAD)/g" zigbee2mqtt/ota/*.json 
+	sed -i "s/refs\/heads\/$(shell git branch --show-current)/$(shell git rev-parse HEAD)/g" zigbee2mqtt/ota/*.json 
 
 
 debug:

--- a/helper_scripts/make_z2m_ota_index.py
+++ b/helper_scripts/make_z2m_ota_index.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 from pathlib import Path
 import yaml
+import subprocess
 
 
 BOARD_TO_MANUFACTURER_NAMES = {
@@ -76,6 +77,18 @@ def make_ota_index_entry(file: Path, base_url: str, manufacturer_names: list[str
         res["manufacturerName"] = manufacturer_names
     return res
 
+def get_raw_github_link():
+    remote_url = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    return f"{remote_url}/raw/refs/heads/{branch}"
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Create Zigbee2mqtt index json",
@@ -83,7 +96,7 @@ if __name__ == "__main__":
     parser.add_argument("filename", metavar="INPUT", type=str, help="OTA filename")
     parser.add_argument("index_file", type=str, help="OTA index.json file")
     parser.add_argument("--base-url", required=False, help="Base url to use", 
-                        default="https://github.com/romasku/tuya-zigbee-switch/raw/refs/heads/main")
+                        default=get_raw_github_link())
     parser.add_argument(
         "--db_file", metavar="INPUT", type=str, help="File with device db"
     )


### PR DESCRIPTION
The repository name and branch were **hardcoded** in the `make_z2m_ota_index.py`.  

Meaning I had to edit the script every time I wanted to run the workflow on my fork  
and revert the edits when I wanted to open a pull request.

So I added two git commands to generate the link for the current branch:  
```
git remote get-url origin
```
```
git branch --show-current
```
This will make contributing a lot easier for me and everyone else.