### PR TITLE
Latch relay125ms pulse

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -177,7 +177,7 @@ MOES_2_GANG_SWITCH_END_DEVICE:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 BSEED_2_GANG_SWITCH:
   name: Bseed-2-gang
-  config_str: Bseed-2-gang;Bseed-2-gang-ED;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
+  config_str: Bseed-2-gang;Bseed-2-gang;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -201,6 +201,32 @@ BSEED_2_GANG_SWITCH_END_DEVICE:
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
+BSEED_2_GANG_SWITCH_2:
+  name: Bseed-2-gang-2
+  config_str: Bseed-2-gang-2;Bseed-2-gang-2;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
+  device_type: router
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 43534
+  stock_converter_model: TS0012
+  tuya_manufacturer_names:
+      - _TZ3000_xk5udnd6
+  human_name: Bseed TS0012 (2 gang switch)
+  status: Supported
+  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
+BSEED_2_GANG_SWITCH_2_END_DEVICE:
+  name: Bseed-2-gang-2
+  config_str: Bseed-2-gang-2;Bseed-2-gang-2-ED;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
+  device_type: end_device
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 43534
+  stock_converter_model: TS0012
+  tuya_manufacturer_names:
+      - _TZ3000_xk5udnd6
+  human_name: Bseed TS0012 (2 gang switch)
+  status: Supported
+  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
 TS0012_AVATTO:
   name: TS0012-custom
   config_str: TS0012-Avatto;TS0012-avatto;BB4f;LB5;SC0f;SC3f;RC2;RC4;

--- a/helper_scripts/make_z2m_ota_index.py
+++ b/helper_scripts/make_z2m_ota_index.py
@@ -76,6 +76,18 @@ def make_ota_index_entry(file: Path, base_url: str, manufacturer_names: list[str
         res["manufacturerName"] = manufacturer_names
     return res
 
+def get_raw_github_link():
+    remote_url = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    branch = subprocess.run(
+        ["git", "branch", "--show-current"],
+        capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    return f"{remote_url}/raw/refs/heads/{branch}"
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Create Zigbee2mqtt index json",
@@ -83,7 +95,7 @@ if __name__ == "__main__":
     parser.add_argument("filename", metavar="INPUT", type=str, help="OTA filename")
     parser.add_argument("index_file", type=str, help="OTA index.json file")
     parser.add_argument("--base-url", required=False, help="Base url to use", 
-                        default="https://github.com/romasku/tuya-zigbee-switch/raw/refs/heads/main")
+                        default=get_raw_github_link())
     parser.add_argument(
         "--db_file", metavar="INPUT", type=str, help="File with device db"
     )

--- a/src/base_components/relay.c
+++ b/src/base_components/relay.c
@@ -11,11 +11,17 @@ void relay_init(relay_t *relay)
 void relay_on(relay_t *relay)
 {
   printf("relay_on\r\n");
-  drv_gpio_write(relay->pin, relay->on_high);
-  if (relay->off_pin)
-  {
-    drv_gpio_write(relay->off_pin, !relay->on_high);
+  
+  if (relay->off_pin) {
+    // Bi-stable latch relay: Pulse ON pin for 125ms
+    drv_gpio_write(relay->pin, relay->on_high);
+    WaitMs(125);
+    drv_gpio_write(relay->pin, !relay->on_high);
+  } else {
+    // Normal relay: Turn on the active pin
+    drv_gpio_write(relay->pin, relay->on_high);
   }
+
   relay->on = 1;
   if (relay->on_change != NULL)
   {
@@ -26,11 +32,17 @@ void relay_on(relay_t *relay)
 void relay_off(relay_t *relay)
 {
   printf("relay_off\r\n");
-  drv_gpio_write(relay->pin, !relay->on_high);
-  if (relay->off_pin)
-  {
+
+  if (relay->off_pin) {
+    // Bi-stable latch relay: Pulse OFF pin for 125ms
     drv_gpio_write(relay->off_pin, relay->on_high);
+    WaitMs(125);
+    drv_gpio_write(relay->off_pin, !relay->on_high);
+  } else {
+    // Normal relay: Turn off the active pin
+    drv_gpio_write(relay->pin, !relay->on_high);
   }
+
   relay->on = 0;
   if (relay->on_change != NULL)
   {

--- a/src/base_components/relay.c
+++ b/src/base_components/relay.c
@@ -13,7 +13,7 @@ void relay_on(relay_t *relay)
   printf("relay_on\r\n");
   
   if (relay->off_pin) {
-    // Bi-stable latch relay: Pulse ON pin for 125ms
+    // Bi-stable Latch relay: Pulse ON pin for 125ms
     drv_gpio_write(relay->pin, relay->on_high);
     WaitMs(125);
     drv_gpio_write(relay->pin, !relay->on_high);
@@ -34,7 +34,7 @@ void relay_off(relay_t *relay)
   printf("relay_off\r\n");
 
   if (relay->off_pin) {
-    // Bi-stable latch relay: Pulse OFF pin for 125ms
+    // Bi-stable Latch relay: Pulse OFF pin for 125ms
     drv_gpio_write(relay->off_pin, relay->on_high);
     WaitMs(125);
     drv_gpio_write(relay->off_pin, !relay->on_high);


### PR DESCRIPTION
Bi-Stable Latch relays only require on/off  pulse and should not be continuously powered. On BSeed 2 gang switches it leads to an endless boot loop, as the 2 coils draw 2x400mW continuously, which is too much without a neutral wire.

According [specs](https://datasheet.octopart.com/HF3F-L-12-1HL1T%28257%29-Hongfa-datasheet-145013251.pdf) the HF3F-L/12-1HLT1 requires a pulse of at least 100ms

related to https://github.com/romasku/tuya-zigbee-switch/commit/10d591444150d27e3290aaf96f7d221a33bb85d1#commitcomment-161738183
https://github.com/romasku/tuya-zigbee-switch/pull/67#issuecomment-3051224997