### PR TITLE
Avatto TS0003 - invert net led and shorter name

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -402,7 +402,7 @@ TS0003:
   github_issue:
 TS0003_AVATTO:
   name: TS0003-Avatto-custom
-  config_str: Tuya-TS0003-Avatto-custom;TS0003-Avatto-custom;BC2u;LD2;SD3u;RC0;SD7u;RD4;SB6u;RC1;
+  config_str: TS0003-AV-CUS;TS0003-AV-CUS;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -410,8 +410,9 @@ TS0003_AVATTO:
   stock_converter_model: TS0003_switch_module_2
   tuya_manufacturer_names:
     - _TZ3000_hbic3ka3
+    - Tuya-TS0003-Avatto-custom
   human_name: Avatto TS0003
-  status: WIP
+  status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/56
 TS0013_GIRIER:
   name: Girier-ZB08-custom

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -133,6 +133,20 @@ TS0002_AVATTO:
   human_name: Avatto TS0002
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
+TS0003_AVATTO:
+  name: TS0003-Avatto-custom
+  config_str: TS0003-AV-CUS;TS0003-AV-CUS;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;
+  device_type: router
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 43543
+  stock_converter_model: TS0003_switch_module_2
+  tuya_manufacturer_names:
+    - _TZ3000_hbic3ka3
+    - Tuya-TS0003-Avatto-custom
+  human_name: Avatto TS0003
+  status: Supported
+  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/56
 TS0004_AVATTO:
   name: TS0004-Avatto-custom
   config_str: TS0004-AV-CUS;TS0004-AV-CUS;BC2u;LD2i;SD7u;RB6;SC0u;RD4;SA0u;RC1;SA1u;RC4;
@@ -400,20 +414,6 @@ TS0003:
   human_name: Moes MS-104CZ
   status: Supported
   github_issue:
-TS0003_AVATTO:
-  name: TS0003-Avatto-custom
-  config_str: TS0003-AV-CUS;TS0003-AV-CUS;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43543
-  stock_converter_model: TS0003_switch_module_2
-  tuya_manufacturer_names:
-    - _TZ3000_hbic3ka3
-    - Tuya-TS0003-Avatto-custom
-  human_name: Avatto TS0003
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/56
 TS0013_GIRIER:
   name: Girier-ZB08-custom
   config_str: Girier-ZB08-custom;ZB08-custom;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;


### PR DESCRIPTION
Similar to 2d67bc7a5ffc6fefeb0cdf1009f293171ca928e8, I updated Avatto TS0003:
- inverted network led
- shorter manufacturer and model name
- moved in-between Avatto 2 and 4 gang

Tested on my device and it works.