### PR TITLE
TS0012 - fix stock converter model

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -208,7 +208,7 @@ TS0012_AVATTO:
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43530
-  stock_converter_model: LZWSM16-2
+  stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
       - _TZ3000_ljhbw1c9 
   human_name: Avatto TS0012
@@ -221,7 +221,7 @@ TS0012_AVATTO_END_DEVICE:
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43530
-  stock_converter_model: LZWSM16-2
+  stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
       - _TZ3000_ljhbw1c9
   human_name: Avatto TS0012


### PR DESCRIPTION
The TS0012 had wrong `stock_converter_module` in the database which generated a useless entry in `tuya_with_ota.js`: `LZWSM16-2`
The device uses `TS0012_switch_module` which was already there from another device.

It probably does not affect anything, but I noticed it was wrong so might as well fix it.

Source: [devices/tuya.ts](https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/tuya.ts#L4352) 

```
fingerprint: tuya.fingerprint("TS0012", ["_TZ3000_jl7qyupf", "_TZ3000_nPGIPl5D", "_TZ3000_kpatq5pq", "_TZ3000_ljhbw1c9", "_TZ3000_4zf0crgo"]),
model: "TS0012_switch_module",
vendor: "Tuya",
description: "2 gang switch module - (without neutral)",
whiteLabel: [
    {vendor: "AVATTO", model: "2gang N-ZLWSM01"},
    tuya.whitelabel("AVATTO", "LZWSM16-2", "2 gang switch module - (without neutral)", ["_TZ3000_kpatq5pq", "_TZ3000_ljhbw1c9"]),
],
```