### PR TITLE
Fix OTA for 4-Gang switches

### DIFF
--- a/src/configs/stack_cfg.h
+++ b/src/configs/stack_cfg.h
@@ -49,7 +49,7 @@
  *  @brief  ZCL: MAX number of cluster list, in cluster number add  + out cluster number
  *
  */
-#define ZCL_CLUSTER_NUM_MAX        20
+#define ZCL_CLUSTER_NUM_MAX        32
 
 /**
  *  @brief  ZCL: maximum number for zcl reporting table


### PR DESCRIPTION
When the config includes 4 switches and 4 relays OTA is not possible anymore due to not enough clusters (clusterId 25 is somehow overwritten and alwys reports "UNSUP_COMMAND").
Can be reproduced with any 3- or 4-Gang module, just enhance the config string.
Basically a size of 22 would be enough for 4-Gang switches, but to be ready for future enhancements I increased it to 32.