### PR TITLE
Always initialize EP1

### DIFF
--- a/src/device_config/config_parser.c
+++ b/src/device_config/config_parser.c
@@ -204,6 +204,10 @@ void parse_config()
 
   u8 total_endpoints = switch_clusters_cnt + relay_clusters_cnt;
 
+  // special case when no switches or relays are defined, so we can init a "clean" device and configure it while running
+  // endpoint 1 still needs to be initialised even though wenn no switches or relays are defined, so it can join the network!
+  if (total_endpoints == 0) total_endpoints = 1;
+
   for (int index = 0; index < total_endpoints; index++)
   {
     endpoints[index].index = index + 1;


### PR DESCRIPTION
Always initialize endpoint 1, even when no relays or switches are defined. 

This it will make it possible to create a "clean" universal binary with no config string in it and let the device still pair and connect to the ZB network. After that the unit can be configured in the UI.

Like this we could probably at some point simplify the various different images to a handfull different (if even needed). Also would. make it much easeir for OTA's.