### PR TITLE
Add make_scripts for easier local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT_NAME = tlc_switch
 BOARD ?= TS0012
 VERSION = 17
 
-DEBUG = 0
+DEBUG ?= 0
 
 SDK_DIR := sdk
 TOOLCHAIN_DIR := toolchain

--- a/make_all.sh
+++ b/make_all.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-yq -r '(keys)[]' device_db.yaml  | while read ITER; do
-    BOARD=$ITER make clean && BOARD=$ITER make -j16
-done
-make update_converters

--- a/make_scripts/make_all.sh
+++ b/make_scripts/make_all.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Builds the firmware for all devices found in device_db.yaml
+#   with up to 16 parallel jobs (-j16) for faster compilation.
+# Updates indexes, converters, quirks, and readme.
+
+# Estimated runtime: 5 mins
+
+# Requires dependencies, sdk and toolchain.
+#   Get them by runnnig make_install.sh.
+
+# Alternatively, build online:
+#   Run the Build Firmware workflow (build.yml) on GitHub Actions.
+
+set -e                                           # Exit on error.
+cd "$(dirname "$(dirname "$(realpath "$0")")")"  # Go to project root.
+
+echo [] > zigbee2mqtt/ota/index_router.json 
+echo [] > zigbee2mqtt/ota/index_end_device.json 
+echo [] > zigbee2mqtt/ota/index_router-FORCE.json 
+echo [] > zigbee2mqtt/ota/index_end_device-FORCE.json 
+
+yq -r '(keys)[]' device_db.yaml | while read ITER; do
+    BOARD=$ITER make clean && BOARD=$ITER make -j16
+done
+
+make update_converters
+make update_zha_quirk
+make update_readme

--- a/make_scripts/make_debug_single.sh
+++ b/make_scripts/make_debug_single.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Builds debugging firmware for a single device
+#   with up to 16 parallel jobs (-j16) for faster compilation.
+# Updates indexes, converters, quirks, and readme.
+
+# Estimated runtime: 5 seconds
+
+# Requires dependencies, sdk and toolchain.
+#   Get them by runnnig make_install.sh.
+
+# Debug flag enables prints. To view them:
+#   connect a serial monitor to the UART TX pin.
+
+# Suggestion: Copy this script to a gitignored folder
+#   and update it for your device.
+
+set -e                                           # Exit on error.
+cd "$(dirname "$(dirname "$(realpath "$0")")")"  # Go to project root.
+
+DEVICE=TS0004_AVATTO  # Change this to your device
+BOARD=$DEVICE make clean && BOARD=$DEVICE DEBUG=1 make -j16
+
+make update_converters
+make update_zha_quirk
+make update_readme

--- a/make_scripts/make_install.sh
+++ b/make_scripts/make_install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Installs dependencies and (re)downloads required sdk and toolchain.
+# Run this script only once after cloning the repository.
+
+set -e                                           # Exit on error.
+cd "$(dirname "$(dirname "$(realpath "$0")")")"  # Go to project root.
+
+sudo apt-get update
+sudo apt-get install -y make python3 python3-jinja2 python3-yaml yq unzip wget
+
+make clean_install
+make install


### PR DESCRIPTION
Hey all... local building was very confusing for me so here's my attempt as making it easier:

I created a new directory `make_scripts/` where you can find some scripts:

- `make_install.sh`: installs dependencies (**apt**) and (re)downloads sdk and toolchain.
- `make_all.sh` (already existed): builds fw for **all devices**; now it also updates converters, quirks and readme.
- `make_debug_single.sh`: build fw for **single device** with prints enabled, also converters, quirks and readme.

I use these on Ubuntu and I opted to get the dependencies from apt.  
Used pip and a virtual environment before, but I like this better.  
I will also suggest this approach on the GitHub Action workflow. Thoughts?

If you use other systems or different package managers please add more scripts or suggest changes.
Also, if this gets merged, I will update the documentation accordingly.