### PR TITLE
Remove pip from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,17 +19,10 @@ jobs:
       with:
         fetch-depth: 0  # Получить полную историю коммитов
 
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y make python3 python3-pip unzip wget
-        python3 -m pip install --upgrade pip
-        pip install yq jinja2
+        sudo apt-get install -y make python3 python3-jinja2 python3-yaml yq unzip wget
 
     - name: Install SDK and Toolchain
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Jinja2==3.1.6
+MarkupSafe==3.0.2
+PyYAML==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-Jinja2==3.1.6
-MarkupSafe==3.0.2
-PyYAML==6.0.2


### PR DESCRIPTION
Cleaned-up the Python setup...  
We can get the dependencies from **apt** and avoid **pip**.

Tested on [remove_pip_build](https://github.com/andrei-lazarov/tuya-zigbee-switch/tree/remove_pip_build) branch and it works well.  
It generated the binaries, quirks, converters and readme.  

Here is the [test run](https://github.com/andrei-lazarov/tuya-zigbee-switch/actions/runs/16661783687) if you want to see the logs.