### PR TITLE
Add empty git-ignored folder 'alpha'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+alpha
 build
 sdk
 toolchain


### PR DESCRIPTION
I needed a directory to store my notes, logs, temporary files, build scripts and I don't want it tracked by git.. so I added it to .gitignore. 

Let's called it alpha so it's easy to find (first in alphabetical order). Could be useful for you guys too.