### PR TITLE
Fix/increase bind table size to 32

### DIFF
--- a/src/configs/stack_cfg.h
+++ b/src/configs/stack_cfg.h
@@ -72,7 +72,7 @@
 /**
  *  @brief  APS: MAX number of binding table size
  */
-#define APS_BINDING_TABLE_NUM      16
+#define APS_BINDING_TABLE_NUM      32
 
 
 /**********************************************************************


### PR DESCRIPTION
When bind table reaches 16 binds obviously no more binds can be made. But also the reportings can't be changed anymore as it always throws a "TABLE_FULL" error. If you bind all 4 buttons to some enddevice with onOff and levelCtrl (see PR #93) together with the standard bindings you get exactly 16 bindings, which make it impossible to change /add reporting! Size increased to 32.