### PR TITLE
Fix `nv_flashSingleItemRemove()` to use correct parameters

### DIFF
--- a/src/device_config/config_nv.c
+++ b/src/device_config/config_nv.c
@@ -28,7 +28,7 @@ void device_config_write_to_nv()
 
 void device_config_remove_from_nv()
 {
-  nv_flashSingleItemRemove(1, NV_MODULE_ZCL, NV_ITEM_ZCL_DEVICE_CONFIG);
+  nv_flashSingleItemRemove(NV_MODULE_ZCL, NV_ITEM_ZCL_DEVICE_CONFIG, sizeof(config.data));
 }
 
 void device_config_read_from_nv()


### PR DESCRIPTION
The api specifies the call as:
`nv_sts_t nv_flashSingleItemRemove(u8 id, u8 itemId, u16 len);`
This PR corrects the use of the call.