### PR TITLE
Multiple pinouts warning

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -183,6 +183,8 @@ TS0004_AVATTO:
   tuya_image_type: 54179
   firmware_image_type: 43529
   stock_converter_model: TS0004_switch_module_2
+  alt_config_str:
+    - TS0004-AVB;TS0004-AVB;BC2u;LD2i;SD7u;RB6;SC0u;RD4;SA0u;RC1;SA1u;RC4;
   tuya_manufacturer_names:
     - _TZ3000_5ajpkyq6 
     - Tuya-TS0004-Avatto-custom

--- a/docs/multiple_pinouts.md
+++ b/docs/multiple_pinouts.md
@@ -1,0 +1,22 @@
+We used to think **Zigbee Manufacturer** can reliably indicate a unique device, but AVATTO has proven us wrong.
+
+There are some devices that have different pinouts, **even if their manufacturer names are identical**.  
+Please trace the board pinout with a multimeter if your device is on the list below (especially if you bought it from a different source).
+
+If your device has the **default pinout**, you can safely proceed with the update (main branch).  
+If your device has a **different pinout**, please request a custom build on the issue page for the respective device.
+
+Known cases:
+
+<details>
+<summary>_TZ3000_5ajpkyq6</summary>
+
+Pinout 1 (was default until v17.x), reported by @paddenstoeltje in [#9](https://github.com/romasku/tuya-zigbee-switch/issues/9):  
+`BC2u;LD2i;SD7u;RB6;SC0u;RD4;SA0u;RC1;SA1u;RC4;`
+
+**Pinout 2 (is default since v17.x)**, reported by @clumsy-stefan and @andrei-lazarov in [#9](https://github.com/romasku/tuya-zigbee-switch/issues/9):  
+`BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;SA0u;RC4;`
+
+</details>
+
+

--- a/helper_scripts/make_z2m_tuya_converters.py
+++ b/helper_scripts/make_z2m_tuya_converters.py
@@ -31,23 +31,41 @@ if __name__ == "__main__":
         for entry in db.values()
         if entry.get("stock_converter_manufacturer", "tuya") == "tuya"
     ]
+    tuyaMultiplePinoutsModels = [
+        entry["stock_converter_model"]
+        for entry in db.values()
+        if entry.get("stock_converter_manufacturer", "tuya") == "tuya" and entry.get("alt_config_str", False)
+    ]
     moesModels = [
         entry["stock_converter_model"]
         for entry in db.values()
         if entry.get("stock_converter_manufacturer", "tuya") == "moes"
+    ]
+    moesMultiplePinoutsModels = [
+        entry["stock_converter_model"]
+        for entry in db.values()
+        if entry.get("stock_converter_manufacturer", "tuya") == "moes" and entry.get("alt_config_str", False)
     ]
     avattoModels = [
         entry["stock_converter_model"]
         for entry in db.values()
         if entry.get("stock_converter_manufacturer", "tuya") == "avatto"
     ]
+    avattoMultiplePinoutsModels = [
+        entry["stock_converter_model"]
+        for entry in db.values()
+        if entry.get("stock_converter_manufacturer", "tuya") == "avatto" and entry.get("alt_config_str", False)
+    ]
 
     template = env.get_template("tuya_with_ota.js.jinja")
 
     print(template.render(
         tuyaModels=sorted(list(set(tuyaModels))),
+        tuyaMultiplePinoutsModels=sorted(list(set(tuyaMultiplePinoutsModels))),
         moesModels=sorted(list(set(moesModels))),
+        moesMultiplePinoutsModels=sorted(list(set(moesMultiplePinoutsModels))),
         avattoModels=sorted(list(set(avattoModels))),
+        avattoMultiplePinoutsModels=sorted(list(set(avattoMultiplePinoutsModels))),
          z2m_v1=args.z2m_v1)
     )
    

--- a/helper_scripts/templates/tuya_with_ota.js.jinja
+++ b/helper_scripts/templates/tuya_with_ota.js.jinja
@@ -1,11 +1,15 @@
 let tuyaDefinitions = require("zigbee-herdsman-converters/devices/tuya");
 let moesDefinitions = require("zigbee-herdsman-converters/devices/moes");
 let avattoDefinitions = require("zigbee-herdsman-converters/devices/avatto");
+let tuya = require("zigbee-herdsman-converters/lib/tuya");
 
 // Support Z2M 2.1.3-1
 tuyaDefinitions = tuyaDefinitions.definitions ?? tuyaDefinitions;
 moesDefinitions = moesDefinitions.definitions ?? moesDefinitions;
 avattoDefinitions = avattoDefinitions.definitions ?? avattoDefinitions;
+
+const definitions = [];
+const multiplePinoutsDescription = "WARNING! There are multiple known pinouts for this device! Before flashing custom firmware, it is recommended you disassemble the device and trace the board pinout. Please check https://github.com/romasku/tuya-zigbee-switch/tree/main/docs/multiple_pinouts.md";
 
 {% if z2m_v1 %}
 const ota = require("zigbee-herdsman-converters/lib/ota");
@@ -17,21 +21,40 @@ const tuyaModels = [
 {% endfor %}
 ];
 
-const definitions = [];
-
+const tuyaMultiplePinoutsModels = [
+{% for item in tuyaMultiplePinoutsModels %}
+    "{{ item }}",
+{% endfor %}
+];
 
 for (let definition of tuyaDefinitions) {
     if (tuyaModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                {% if z2m_v1 %}
-                ota: ota.zigbeeOTA,
-                {% else %}
-                ota: true,
-                {% endif%}
-            }
-        )
+        if (tuyaMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    {% if z2m_v1 %}
+                    ota: ota.zigbeeOTA,
+                    {% else %}
+                    ota: true,
+                    {% endif%}
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    {% if z2m_v1 %}
+                    ota: ota.zigbeeOTA,
+                    {% else %}
+                    ota: true,
+                    {% endif%}
+                }
+            )
+        }
     }
 }
 
@@ -41,18 +64,40 @@ const moesModels = [
 {% endfor %}
 ];
 
+const moesMultiplePinoutsModels = [
+{% for item in moesMultiplePinoutsModels %}
+    "{{ item }}",
+{% endfor %}
+];
+
 for (let definition of moesDefinitions) {
     if (moesModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                {% if z2m_v1 %}
-                ota: ota.zigbeeOTA,
-                {% else %}
-                ota: true,
-                {% endif%}
-            }
-        )
+        if (moesMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    {% if z2m_v1 %}
+                    ota: ota.zigbeeOTA,
+                    {% else %}
+                    ota: true,
+                    {% endif%}
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    {% if z2m_v1 %}
+                    ota: ota.zigbeeOTA,
+                    {% else %}
+                    ota: true,
+                    {% endif%}
+                }
+            )
+        }
     }
 }
 
@@ -62,18 +107,40 @@ const avattoModels = [
 {% endfor %}
 ];
 
+const avattoMultiplePinoutsModels = [
+{% for item in avattoMultiplePinoutsModels %}
+    "{{ item }}",
+{% endfor %}
+];
+
 for (let definition of avattoDefinitions) {
     if (avattoModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                {% if z2m_v1 %}
-                ota: ota.zigbeeOTA,
-                {% else %}
-                ota: true,
-                {% endif%}
-            }
-        )
+        if (avattoMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    {% if z2m_v1 %}
+                    ota: ota.zigbeeOTA,
+                    {% else %}
+                    ota: true,
+                    {% endif%}
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    {% if z2m_v1 %}
+                    ota: ota.zigbeeOTA,
+                    {% else %}
+                    ota: true,
+                    {% endif%}
+                }
+            )
+        }
     }
 }
 

--- a/zigbee2mqtt/converters/tuya_with_ota.js
+++ b/zigbee2mqtt/converters/tuya_with_ota.js
@@ -1,11 +1,15 @@
 let tuyaDefinitions = require("zigbee-herdsman-converters/devices/tuya");
 let moesDefinitions = require("zigbee-herdsman-converters/devices/moes");
 let avattoDefinitions = require("zigbee-herdsman-converters/devices/avatto");
+let tuya = require("zigbee-herdsman-converters/lib/tuya");
 
 // Support Z2M 2.1.3-1
 tuyaDefinitions = tuyaDefinitions.definitions ?? tuyaDefinitions;
 moesDefinitions = moesDefinitions.definitions ?? moesDefinitions;
 avattoDefinitions = avattoDefinitions.definitions ?? avattoDefinitions;
+
+const definitions = [];
+const multiplePinoutsDescription = "WARNING! There are multiple known pinouts for this device! Before flashing custom firmware, it is recommended you disassemble the device and trace the board pinout. Please check https://github.com/romasku/tuya-zigbee-switch/tree/main/docs/multiple_pinouts.md";
 
 
 const tuyaModels = [
@@ -25,17 +29,30 @@ const tuyaModels = [
     "WHD02",
 ];
 
-const definitions = [];
-
+const tuyaMultiplePinoutsModels = [
+    "TS0004_switch_module_2",
+];
 
 for (let definition of tuyaDefinitions) {
     if (tuyaModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                ota: true,
-            }
-        )
+        if (tuyaMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    ota: true,
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    ota: true,
+                }
+            )
+        }
     }
 }
 
@@ -43,14 +60,29 @@ const moesModels = [
     "ZS-EUB_1gang",
 ];
 
+const moesMultiplePinoutsModels = [
+];
+
 for (let definition of moesDefinitions) {
     if (moesModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                ota: true,
-            }
-        )
+        if (moesMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    ota: true,
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    ota: true,
+                }
+            )
+        }
     }
 }
 
@@ -58,14 +90,29 @@ const avattoModels = [
     "LZWSM16-1",
 ];
 
+const avattoMultiplePinoutsModels = [
+];
+
 for (let definition of avattoDefinitions) {
     if (avattoModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                ota: true,
-            }
-        )
+        if (avattoMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    ota: true,
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    ota: true,
+                }
+            )
+        }
     }
 }
 

--- a/zigbee2mqtt/converters_v1/tuya_with_ota.js
+++ b/zigbee2mqtt/converters_v1/tuya_with_ota.js
@@ -1,11 +1,15 @@
 let tuyaDefinitions = require("zigbee-herdsman-converters/devices/tuya");
 let moesDefinitions = require("zigbee-herdsman-converters/devices/moes");
 let avattoDefinitions = require("zigbee-herdsman-converters/devices/avatto");
+let tuya = require("zigbee-herdsman-converters/lib/tuya");
 
 // Support Z2M 2.1.3-1
 tuyaDefinitions = tuyaDefinitions.definitions ?? tuyaDefinitions;
 moesDefinitions = moesDefinitions.definitions ?? moesDefinitions;
 avattoDefinitions = avattoDefinitions.definitions ?? avattoDefinitions;
+
+const definitions = [];
+const multiplePinoutsDescription = "WARNING! There are multiple known pinouts for this device! Before flashing custom firmware, it is recommended you disassemble the device and trace the board pinout. Please check https://github.com/romasku/tuya-zigbee-switch/tree/main/docs/multiple_pinouts.md";
 
 const ota = require("zigbee-herdsman-converters/lib/ota");
 
@@ -26,17 +30,30 @@ const tuyaModels = [
     "WHD02",
 ];
 
-const definitions = [];
-
+const tuyaMultiplePinoutsModels = [
+    "TS0004_switch_module_2",
+];
 
 for (let definition of tuyaDefinitions) {
     if (tuyaModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                ota: ota.zigbeeOTA,
-            }
-        )
+        if (tuyaMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    ota: ota.zigbeeOTA,
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    ota: ota.zigbeeOTA,
+                }
+            )
+        }
     }
 }
 
@@ -44,14 +61,29 @@ const moesModels = [
     "ZS-EUB_1gang",
 ];
 
+const moesMultiplePinoutsModels = [
+];
+
 for (let definition of moesDefinitions) {
     if (moesModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                ota: ota.zigbeeOTA,
-            }
-        )
+        if (moesMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    ota: ota.zigbeeOTA,
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    ota: ota.zigbeeOTA,
+                }
+            )
+        }
     }
 }
 
@@ -59,14 +91,29 @@ const avattoModels = [
     "LZWSM16-1",
 ];
 
+const avattoMultiplePinoutsModels = [
+];
+
 for (let definition of avattoDefinitions) {
     if (avattoModels.includes(definition.model)) {
-        definitions.push(
-            {
-                ...definition,
-                ota: ota.zigbeeOTA,
-            }
-        )
+        if (avattoMultiplePinoutsModels.includes(definition.model)) {
+            definitions.push(
+                {
+                    ...definition,
+                    description: multiplePinoutsDescription,
+                    whiteLabel: definition.whiteLabel.map(entry => ({...entry, description: multiplePinoutsDescription,})),
+                    ota: ota.zigbeeOTA,
+                }
+            )
+        }
+        else {
+            definitions.push(
+                {
+                    ...definition,
+                    ota: ota.zigbeeOTA,
+                }
+            )
+        }
     }
 }
 


### PR DESCRIPTION
- added [multiple_pinouts doc](https://github.com/andrei-lazarov/tuya-zigbee-switch/blob/dfb6dcd45f1d583f613244433d77b156a09841f9/docs/multiple_pinouts.md)
- added warning in tuya converter
- added alternative config string in db for avb 4gang

There's one device with different pinout reports... so I wanted to give users a warning before they update.
My idea was to update the description with a big warning and a link to the docs. (see screenshot below)

Even if it's only one device, I took the time to automate it:

I suggest the new `alt_config_str` field in the database, which should keep alternative config strings/pinouts.
If it is populated, the script will automatically add the warning to the tuya converters.

Note that I already run the script so you can see the new converter.

If you have suggestions on how to make it more visible, please share.
I was also thinking about the patch notes message you get when you check something for updates. (IKEA bulbs for example)

<img width="919" height="785" alt="Screenshot From 2025-08-06 23-53-18" src="https://github.com/user-attachments/assets/e6e1a38d-554a-4ab7-855b-7c6036a6ec58" />