### PR TITLE
Clean database and converters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,18 @@ jobs:
 
     - name: Build for all boards
       run: |
-        yq -r '(keys)[]' device_db.yaml | while read ITER; do
-          echo "Building for board: $ITER"
-          BOARD=$ITER make clean && BOARD=$ITER make -j16 || exit 1
-          echo "Checking if files were created for board: $ITER"
+        yq -r 'to_entries | sort_by(.key)[] | "\(.key) \(.value.device_type)"' device_db.yaml | while read ITER TYPE; do
+          echo "Building for board: $ITER (router)"
+          BOARD=$ITER DEVICE_TYPE=router make clean && BOARD=$ITER DEVICE_TYPE=router make -j16 || exit 1
+          echo "Checking if files were created for board: $ITER (router)"
           ls -l bin/$ITER/
+
+          echo "Building for board: $ITER (end_device)"
+          if [ "$TYPE" = "end_device" ]; then
+            BOARD=${ITER} DEVICE_TYPE=end_device make clean && BOARD=${ITER} DEVICE_TYPE=end_device make -j16 || exit 1
+            echo "Checking if files were created for board: $ITER (end_device)"
+            ls -l bin/${ITER}_END_DEVICE/
+          fi
         done
 
     - name: Update Z2M converters

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT_NAME = tlc_switch
 
 BOARD ?= TS0012
-VERSION = 18
+VERSION := 18
 
 DEBUG ?= 0
 
@@ -17,7 +17,7 @@ DEVICE_DB_FILE := device_db.yaml
 
 # Board and version defines
 
-DEVICE_TYPE := $(shell yq -r .$(BOARD).device_type $(DEVICE_DB_FILE))
+DEVICE_TYPE ?= $(shell yq -r .$(BOARD).device_type $(DEVICE_DB_FILE))
 CONFIG_STR := $(shell yq -r .$(BOARD).config_str $(DEVICE_DB_FILE))
 FROM_TUYA_MANUFACTURER_ID := $(shell yq -r .$(BOARD).tuya_manufacturer_id $(DEVICE_DB_FILE))
 FROM_TUYA_IMAGE_TYPE := $(shell yq -r .$(BOARD).tuya_image_type $(DEVICE_DB_FILE))
@@ -26,11 +26,13 @@ FIRMWARE_IMAGE_TYPE := $(shell yq -r .$(BOARD).firmware_image_type $(DEVICE_DB_F
 ifeq ($(DEVICE_TYPE), router)
 	TEL_CHIP := -DMCU_CORE_8258=1 -DROUTER=1 -DMCU_STARTUP_8258=1
 	LIBS := -ldrivers_8258 -lzb_router
+	BOARD_FILE := $(BOARD)
 endif
 
 ifeq ($(DEVICE_TYPE), end_device)
 	TEL_CHIP := -DMCU_CORE_8258=1 -DEND_DEVICE=1 -DMCU_STARTUP_8258=1 -DPM_ENABLE
 	LIBS := -ldrivers_8258 -lzb_ed
+	BOARD_FILE := $(BOARD)_END_DEVICE
 endif
 
 
@@ -45,7 +47,7 @@ endif
 PROJECT_PATH := .
 
 BUILD_PATH :=$(PROJECT_PATH)/$(BUILD_DIR)
-BIN_PATH := $(PROJECT_PATH)/$(BIN_DIR)/$(BOARD)
+BIN_PATH := $(PROJECT_PATH)/$(BIN_DIR)/$(BOARD_FILE)
 TC32_PATH := $(PROJECT_PATH)/$(TOOLCHAIN_DIR)/tc32/bin
 SRC_PATH := $(PROJECT_PATH)/$(SRC_DIR)
 SDK_PATH := $(PROJECT_PATH)/$(SDK_DIR)
@@ -130,12 +132,12 @@ LS_FLAGS := $(SRC_PATH)/boot.link
 -include makefiles/zigbee.mk
 
 
-LST_FILE := $(BUILD_PATH)/$(PROJECT_NAME)-$(BOARD).lst
+LST_FILE := $(BUILD_PATH)/$(PROJECT_NAME)-$(BOARD_FILE).lst
 BIN_FILE := $(BIN_PATH)/$(PROJECT_NAME).bin
 OTA_FILE := $(BIN_PATH)/$(PROJECT_NAME).zigbee
 FROM_TUYA_OTA_FILE := $(BIN_PATH)/$(PROJECT_NAME)-from_tuya.zigbee
 FORCE_OTA_FILE:= $(BIN_PATH)/$(PROJECT_NAME)-forced.zigbee
-ELF_FILE := $(BUILD_PATH)/$(PROJECT_NAME)-$(BOARD).elf
+ELF_FILE := $(BUILD_PATH)/$(PROJECT_NAME)-$(BOARD_FILE).elf
 
 Z2M_INDEX_FILE := zigbee2mqtt/ota/index_$(DEVICE_TYPE).json
 

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -8,8 +8,8 @@ TS0012:
   - TS0042-CUSTOM
   - TS0012-custom-end-device
   stock_converter_model: TS0012_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_jl7qyupf  # Initial device
+  tuya_manufacturer_name: _TZ3000_jl7qyupf  # Initial device
+  old_manufacturer_names:
   - Tuya-CUSTOM   # Old name from early firmware
   - Tuya-TS0012-custom
   human_name: GIRIER TS0012, OXT
@@ -21,8 +21,8 @@ WHD02:
   tuya_image_type: 524
   firmware_image_type: 43522
   stock_converter_model: WHD02
-  tuya_manufacturer_names:
-  - _TZ3000_skueekg3
+  tuya_manufacturer_name: _TZ3000_skueekg3
+  old_manufacturer_names:
   - Tuya-WHD02-custom
   human_name: No-name 1 gang switch
   status: Supported
@@ -33,8 +33,8 @@ TS0002:
   tuya_image_type: 54179
   firmware_image_type: 43523
   stock_converter_model: TS0002_basic
-  tuya_manufacturer_names:
-  - _TZ3000_01gpyda5
+  tuya_manufacturer_name: _TZ3000_01gpyda5
+  old_manufacturer_names:
   - Tuya-TS0002-custom
   human_name: OXT TS0001, probably other rebrands
   status: Supported
@@ -46,8 +46,8 @@ TS0002_OXT:
   tuya_image_type: 54179
   firmware_image_type: 43547
   stock_converter_model: TS0002_basic
-  tuya_manufacturer_names:
-  - _TZ3000_bvrlqyj7
+  tuya_manufacturer_name: _TZ3000_bvrlqyj7
+  old_manufacturer_names:
   - TS0002-OXT-CUS
   zb_module: ZT3L
   human_name: OXT 2-gang switch
@@ -60,8 +60,8 @@ TS0011:
   tuya_image_type: 54179
   firmware_image_type: 43524
   stock_converter_model: TS0011_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_ji4araar
+  tuya_manufacturer_name: _TZ3000_ji4araar
+  old_manufacturer_names:
   - Tuya-TS0011-custom
   human_name: GIRIER TS0011, OXT TS0011
   status: Supported
@@ -73,8 +73,8 @@ TS0001:
   tuya_image_type: 54179
   firmware_image_type: 43525
   stock_converter_model: TS0001_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_tqlv4ug4
+  tuya_manufacturer_name: _TZ3000_tqlv4ug4
+  old_manufacturer_names:
   - Tuya-TS0001-custom
   human_name: OXT TS0001, probably other rebrands
   status: Supported
@@ -86,8 +86,8 @@ TS0002_GIRIER:
   tuya_image_type: 54179
   firmware_image_type: 43526
   stock_converter_model: TS0002_basic
-  tuya_manufacturer_names:
-  - _TZ3000_zmy4lslw
+  tuya_manufacturer_name: _TZ3000_zmy4lslw
+  old_manufacturer_names:
   - Tuya-TS0002-custom
   zb_module: ZT2S
   human_name: GIRIER 2 Gang
@@ -100,8 +100,8 @@ TS0001_AVATTO:
   tuya_image_type: 54179
   firmware_image_type: 43527
   stock_converter_model: TS0001_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_4rbqgcuv
+  tuya_manufacturer_name: _TZ3000_4rbqgcuv
+  old_manufacturer_names:
   - Tuya-TS0001-Avatto-custom
   - TS0001-AV-CUS
   - TS0001-AVB
@@ -120,8 +120,8 @@ TS0002_AVATTO:
   tuya_image_type: 54179
   firmware_image_type: 43528
   stock_converter_model: TS0002_limited
-  tuya_manufacturer_names:
-  - _TZ3000_mtnpt6ws
+  tuya_manufacturer_name: _TZ3000_mtnpt6ws
+  old_manufacturer_names:
   - Tuya-TS0002-Avatto-custom
   - TS0002-AV-CUS
   - TS0002-AVB
@@ -140,8 +140,8 @@ TS0003_AVATTO:
   tuya_image_type: 54179
   firmware_image_type: 43543
   stock_converter_model: TS0003_switch_module_2
-  tuya_manufacturer_names:
-  - _TZ3000_hbic3ka3
+  tuya_manufacturer_name: _TZ3000_hbic3ka3
+  old_manufacturer_names:
   - Tuya-TS0003-Avatto-custom
   - TS0003-AV-CUS
   - TS0003-AVB
@@ -160,8 +160,8 @@ TS0004_AVATTO:
   tuya_image_type: 54179
   firmware_image_type: 43529
   stock_converter_model: TS0004_switch_module_2
-  tuya_manufacturer_names:
-  - _TZ3000_5ajpkyq6
+  tuya_manufacturer_name: _TZ3000_5ajpkyq6
+  old_manufacturer_names:
   - Tuya-TS0004-Avatto-custom
   - TS0004-AV-CUS
   - TS0004-AVB
@@ -182,8 +182,8 @@ MOES_2_GANG_SWITCH:
   stock_converter_model: TS0012
   old_zb_models:
   - Moes-2-gang-ED
-  tuya_manufacturer_names:
-  - _TZ3000_18ejxno0
+  tuya_manufacturer_name: _TZ3000_18ejxno0
+  old_manufacturer_names:
   - Moes-2-gang
   zb_module: ZTU
   override_z2m_device: ZS-EUB_2gang
@@ -199,8 +199,8 @@ BSEED_2_GANG_SWITCH:
   stock_converter_model: TS0012
   old_zb_models:
   - Bseed-2-gang-ED
-  tuya_manufacturer_names:
-  - _TZ3000_f2slq5pj
+  tuya_manufacturer_name: _TZ3000_f2slq5pj
+  old_manufacturer_names:
   - Bseed-2-gang
   zb_module: ZTU
   human_name: Bseed TS0012 (2 gang switch)
@@ -215,8 +215,8 @@ BSEED_2_GANG_SWITCH_2:
   stock_converter_model: TS0012
   old_zb_models:
   - Bseed-2-gang-2-ED
-  tuya_manufacturer_names:
-  - _TZ3000_xk5udnd6
+  tuya_manufacturer_name: _TZ3000_xk5udnd6
+  old_manufacturer_names:
   - Bseed-2-gang-2
   zb_module: ZTU
   human_name: Bseed TS0012 (2 gang switch)
@@ -231,8 +231,8 @@ TS0012_AVATTO:
   stock_converter_model: TS0012_switch_module
   old_zb_models:
   - TS0012-avatto-ED
-  tuya_manufacturer_names:
-  - _TZ3000_ljhbw1c9
+  tuya_manufacturer_name: _TZ3000_ljhbw1c9
+  old_manufacturer_names:
   - TS0012-Avatto
   zb_module: ZTU
   human_name: Avatto TS0012
@@ -248,8 +248,8 @@ WHD02_AUBESS:
   stock_converter_model: WHD02
   old_zb_models:
   - WHD02-Aubess-ED
-  tuya_manufacturer_names:
-  - _TZ3000_46t1rvdu
+  tuya_manufacturer_name: _TZ3000_46t1rvdu
+  old_manufacturer_names:
   - WHD02-Aubess
   zb_module: ZT2S
   human_name: Aubess WHD02
@@ -265,8 +265,8 @@ MOES_1_GANG_SWITCH:
   stock_converter_manufacturer: moes
   old_zb_models:
   - Moes-1-gang-ED
-  tuya_manufacturer_names:
-  - _TZ3000_hhiodade
+  tuya_manufacturer_name: _TZ3000_hhiodade
+  old_manufacturer_names:
   - Moes-1-gang
   zb_module: ZTU
   human_name: Moes TS0011 (1 gang switch)
@@ -281,8 +281,8 @@ MOES_3_GANG_SWITCH:
   stock_converter_model: TS0013
   old_zb_models:
   - Moes-3-gang-ED
-  tuya_manufacturer_names:
-  - _TZ3000_qewo8dlz
+  tuya_manufacturer_name: _TZ3000_qewo8dlz
+  old_manufacturer_names:
   - Moes-3-gang
   zb_module: ZTU
   human_name: Moes TS0013 (3 gang switch)
@@ -295,8 +295,8 @@ WHD02_2:
   tuya_image_type: 54179
   firmware_image_type: 43535
   stock_converter_model: WHD02
-  tuya_manufacturer_names:
-  - _TZ3000_skueekg3
+  tuya_manufacturer_name: _TZ3000_skueekg3
+  old_manufacturer_names:
   - Tuya-WHD02-custom
   zb_module: ZT2S
   human_name: No-name 1 gang switch with no rf shiled ZT2S
@@ -309,8 +309,8 @@ WHD02_3:
   tuya_image_type: 518
   firmware_image_type: 43541
   stock_converter_model: WHD02
-  tuya_manufacturer_names:
-  - _TZ3000_skueekg3
+  tuya_manufacturer_name: _TZ3000_skueekg3
+  old_manufacturer_names:
   - Tuya-WHD02-custom
   zb_module: ZT2S
   human_name: No-name 1 gang switch with no rf shiled ZT2S
@@ -325,8 +325,8 @@ ZEMISMART_2_GANG:
   stock_converter_model: TS0012
   old_zb_models:
   - Zemi-2-gang-ED
-  tuya_manufacturer_names:
-  - _TZ3000_zmlunnhy
+  tuya_manufacturer_name: _TZ3000_zmlunnhy
+  old_manufacturer_names:
   - Zemi-2-gang
   zb_module: ZT3L
   human_name: Internet search says this is Zemismart 2 gang switch, needs confirmation
@@ -342,8 +342,8 @@ TS0011_AVATTO:
   stock_converter_model: LZWSM16-1
   old_zb_models:
   - TS0011-avatto-ED
-  tuya_manufacturer_names:
-  - _TZ3000_hbxsdd6k
+  tuya_manufacturer_name: _TZ3000_hbxsdd6k
+  old_manufacturer_names:
   - TS0011-Avatto
   zb_module: ZTU
   human_name: Avatto TS0011
@@ -356,8 +356,8 @@ TS0003:
   tuya_image_type: 54179
   firmware_image_type: 43538
   stock_converter_model: TS0003
-  tuya_manufacturer_names:
-  - _TZ3000_pfc7i3kt
+  tuya_manufacturer_name: _TZ3000_pfc7i3kt
+  old_manufacturer_names:
   - Tuya-TS0003-custom
   human_name: Moes MS-104CZ
   status: Supported
@@ -369,8 +369,8 @@ TS0003_IHS:
   tuya_image_type: 54179
   firmware_image_type: 43546
   stock_converter_model: TS0003_switch_module_2
-  tuya_manufacturer_names:
-  - _TZ3000_mhhxxjrs
+  tuya_manufacturer_name: _TZ3000_mhhxxjrs
+  old_manufacturer_names:
   - TS0003-3CH-cus
   - TS0003-IHS
   old_zb_models:
@@ -386,8 +386,8 @@ TS0004_IHS:
   tuya_image_type: 54179
   firmware_image_type: 43548
   stock_converter_model: TS0004_switch_module_2
-  tuya_manufacturer_names:
-  - _TZ3000_knoj8lpk
+  tuya_manufacturer_name: _TZ3000_knoj8lpk
+  old_manufacturer_names:
   - TS0004-IHS
   zb_module: ZTU
   human_name: IHSENO 4-gang Neutral
@@ -403,8 +403,8 @@ TS0013_GIRIER:
   override_z2m_device: ZB08
   old_zb_models:
   - ZB08-custom-ED
-  tuya_manufacturer_names:
-  - _TZ3000_ypgri8yz
+  tuya_manufacturer_name: _TZ3000_ypgri8yz
+  old_manufacturer_names:
   - Girier-ZB08-custom
   - Girier-ZB08-custom-ED
   zb_module: ZTU # probably but not confirmed
@@ -418,8 +418,8 @@ TS0004_AVATTO_NEUTRAL:
   tuya_image_type: 54179
   firmware_image_type: 43540
   stock_converter_model: TS0004_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_ltt60asa
+  tuya_manufacturer_name: _TZ3000_ltt60asa
+  old_manufacturer_names:
   - TS0004-Avv
   zb_module: ZTU
   human_name: Avatto 4 gang switch module with N
@@ -432,8 +432,8 @@ TS0004:
   tuya_image_type: 54179
   firmware_image_type: 43545
   stock_converter_model: TS0004_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_mmkbptmx
+  tuya_manufacturer_name: _TZ3000_mmkbptmx
+  old_manufacturer_names:
   - Tuya-TS0004-custom
   zb_module: ZTU
   human_name: No-name 4 gang switch module with N
@@ -446,8 +446,8 @@ AVATTO_3_GANG_TOUCH:
   tuya_image_type: 54179
   firmware_image_type: 43542
   stock_converter_model: TS0003_switch_3_gang
-  tuya_manufacturer_names:
-  - _TZ3000_avky2mvc
+  tuya_manufacturer_name: _TZ3000_avky2mvc
+  old_manufacturer_names:
   - Avatto-3-touch
   # override_z2m_device: 37022474_2
   zb_module: ZTU

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -49,6 +49,7 @@ TS0002_OXT:
   tuya_manufacturer_names:
   - _TZ3000_bvrlqyj7
   - TS0002-OXT-CUS
+  zb_module: ZT3L
   human_name: OXT 2-gang switch
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/49
@@ -88,6 +89,7 @@ TS0002_GIRIER:
   tuya_manufacturer_names:
   - _TZ3000_zmy4lslw
   - Tuya-TS0002-custom
+  zb_module: ZT2S
   human_name: GIRIER 2 Gang
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/29
@@ -106,6 +108,7 @@ TS0001_AVATTO:
   old_zb_models:
   - TS0001-Avatto-custom
   - TS0001-AV-CUS
+  zb_module: ZTU
   override_z2m_device: ZWSM16-1-Zigbee
   human_name: AVATTO ZWSM16-1-Zigbee (blue socket)
   status: Supported
@@ -125,6 +128,7 @@ TS0002_AVATTO:
   old_zb_models:
   - TS0002-Avatto-custom
   - TS0002-AV-CUS
+  zb_module: ZTU
   override_z2m_device: ZWSM16-2-Zigbee
   human_name: AVATTO ZWSM16-2-Zigbee (blue socket)
   status: Supported
@@ -144,6 +148,7 @@ TS0003_AVATTO:
   old_zb_models:
   - TS0003-Avatto-custom
   - TS0003-AV-CUS
+  zb_module: ZTU
   override_z2m_device: ZWSM16-3-Zigbee
   human_name: AVATTO ZWSM16-3-Zigbee (blue socket)
   status: Supported
@@ -163,6 +168,7 @@ TS0004_AVATTO:
   old_zb_models:
   - TS0004-Avatto-custom
   - TS0004-AV-CUS
+  zb_module: ZTU
   override_z2m_device: ZWSM16-4-Zigbee
   human_name: AVATTO ZWSM16-4-Zigbee (blue socket)
   status: Supported
@@ -179,6 +185,7 @@ MOES_2_GANG_SWITCH:
   tuya_manufacturer_names:
   - _TZ3000_18ejxno0
   - Moes-2-gang
+  zb_module: ZTU
   override_z2m_device: ZS-EUB_2gang
   human_name: Moes TS0012 (2 gang switch)
   status: Supported
@@ -195,6 +202,7 @@ BSEED_2_GANG_SWITCH:
   tuya_manufacturer_names:
   - _TZ3000_f2slq5pj
   - Bseed-2-gang
+  zb_module: ZTU
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
@@ -210,6 +218,7 @@ BSEED_2_GANG_SWITCH_2:
   tuya_manufacturer_names:
   - _TZ3000_xk5udnd6
   - Bseed-2-gang-2
+  zb_module: ZTU
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
@@ -225,6 +234,7 @@ TS0012_AVATTO:
   tuya_manufacturer_names:
   - _TZ3000_ljhbw1c9
   - TS0012-Avatto
+  zb_module: ZTU
   human_name: Avatto TS0012
   override_z2m_device: LZWSM16-2
   status: Supported
@@ -241,6 +251,7 @@ WHD02_AUBESS:
   tuya_manufacturer_names:
   - _TZ3000_46t1rvdu
   - WHD02-Aubess
+  zb_module: ZT2S
   human_name: Aubess WHD02
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/18
@@ -257,6 +268,7 @@ MOES_1_GANG_SWITCH:
   tuya_manufacturer_names:
   - _TZ3000_hhiodade
   - Moes-1-gang
+  zb_module: ZTU
   human_name: Moes TS0011 (1 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
@@ -272,6 +284,7 @@ MOES_3_GANG_SWITCH:
   tuya_manufacturer_names:
   - _TZ3000_qewo8dlz
   - Moes-3-gang
+  zb_module: ZTU
   human_name: Moes TS0013 (3 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
@@ -285,6 +298,7 @@ WHD02_2:
   tuya_manufacturer_names:
   - _TZ3000_skueekg3
   - Tuya-WHD02-custom
+  zb_module: ZT2S
   human_name: No-name 1 gang switch with no rf shiled ZT2S
   status: In progress, tuya_manufacturer_name is not confirmed
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/24
@@ -298,6 +312,7 @@ WHD02_3:
   tuya_manufacturer_names:
   - _TZ3000_skueekg3
   - Tuya-WHD02-custom
+  zb_module: ZT2S
   human_name: No-name 1 gang switch with no rf shiled ZT2S
   status: In progress, tuya_manufacturer_name is not confirmed
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/44
@@ -313,6 +328,7 @@ ZEMISMART_2_GANG:
   tuya_manufacturer_names:
   - _TZ3000_zmlunnhy
   - Zemi-2-gang
+  zb_module: ZT3L
   human_name: Internet search says this is Zemismart 2 gang switch, needs confirmation
   status: In progress
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/19
@@ -329,6 +345,7 @@ TS0011_AVATTO:
   tuya_manufacturer_names:
   - _TZ3000_hbxsdd6k
   - TS0011-Avatto
+  zb_module: ZTU
   human_name: Avatto TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
@@ -358,6 +375,7 @@ TS0003_IHS:
   - TS0003-IHS
   old_zb_models:
   - TS0003-3CH-cus
+  zb_module: ZTU
   human_name: IHSENO 3-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/85
@@ -371,6 +389,7 @@ TS0004_IHS:
   tuya_manufacturer_names:
   - _TZ3000_knoj8lpk
   - TS0004-IHS
+  zb_module: ZTU
   human_name: IHSENO 4-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/105
@@ -388,6 +407,7 @@ TS0013_GIRIER:
   - _TZ3000_ypgri8yz
   - Girier-ZB08-custom
   - Girier-ZB08-custom-ED
+  zb_module: ZTU # probably but not confirmed
   human_name: Girier-ZB08
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/37
@@ -401,6 +421,7 @@ TS0004_AVATTO_NEUTRAL:
   tuya_manufacturer_names:
   - _TZ3000_ltt60asa
   - TS0004-Avv
+  zb_module: ZTU
   human_name: Avatto 4 gang switch module with N
   status: WIP, check issue for current status.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/42
@@ -414,6 +435,7 @@ TS0004:
   tuya_manufacturer_names:
   - _TZ3000_mmkbptmx
   - Tuya-TS0004-custom
+  zb_module: ZTU
   human_name: No-name 4 gang switch module with N
   status: Untested
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/66
@@ -428,6 +450,7 @@ AVATTO_3_GANG_TOUCH:
   - _TZ3000_avky2mvc
   - Avatto-3-touch
   # override_z2m_device: 37022474_2
+  zb_module: ZTU
   human_name: Avatto Zigbee 3 Gang (ZTS02RD-US-W3)
   status: WIP, expiremntal, see issue.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/41

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1,30 +1,16 @@
 TS0012:
   config_str: jl7qyupf;TS0012-custom;BA0f;LD7;SC2f;SC3f;RC0;RB4;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43521
-  old_zb_models:
-  - TS0042-CUSTOM
-  stock_converter_model: TS0012_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_jl7qyupf  # Initial device
-  - Tuya-CUSTOM   # Old name from early firmware
-  - Tuya-TS0012-custom
-  human_name: GIRIER TS0012, OXT
-  status: Supported
-TS0012_END_DEVICE:
-  config_str: jl7qyupf;TS0012-custom-end-device;BA0f;LD7;SC2f;SC3f;RC0;RB4;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43521
   old_zb_models:
   - TS0042-CUSTOM
+  - TS0012-custom-end-device
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
-  - _TZ3000_jl7qyupf
-  - Tuya-CUSTOM
+  - _TZ3000_jl7qyupf  # Initial device
+  - Tuya-CUSTOM   # Old name from early firmware
   - Tuya-TS0012-custom
   human_name: GIRIER TS0012, OXT
   status: Supported
@@ -67,19 +53,6 @@ TS0002_OXT:
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/49
 TS0011:
-  config_str: ji4araar;TS0011-custom;BA0f;LD7;SC2f;RC0;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43524
-  stock_converter_model: TS0011_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_ji4araar
-  - Tuya-TS0011-custom
-  human_name: GIRIER TS0011, OXT TS0011
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/4
-TS0011_END_DEVICE:
   config_str: ji4araar;TS0011-custom;BA0f;LD7;SC2f;RC0;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -196,50 +169,29 @@ TS0004_AVATTO:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
 MOES_2_GANG_SWITCH:
   config_str: 18ejxno0;Moes-2-gang;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43510
-  stock_converter_model: TS0012
-  tuya_manufacturer_names:
-  - _TZ3000_18ejxno0
-  - Moes-2-gang
-  human_name: Moes TS0012 (2 gang switch)
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
-MOES_2_GANG_SWITCH_END_DEVICE:
-  config_str: 18ejxno0;Moes-2-gang-ED;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43510
   stock_converter_model: TS0012
+  old_zb_models:
+  - Moes-2-gang-ED
   tuya_manufacturer_names:
   - _TZ3000_18ejxno0
   - Moes-2-gang
+  override_z2m_device: ZS-EUB_2gang
   human_name: Moes TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 BSEED_2_GANG_SWITCH:
   config_str: f2slq5pj;Bseed-2-gang;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43534
-  stock_converter_model: TS0012
-  tuya_manufacturer_names:
-  - _TZ3000_f2slq5pj
-  - Bseed-2-gang
-  human_name: Bseed TS0012 (2 gang switch)
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
-BSEED_2_GANG_SWITCH_END_DEVICE:
-  config_str: f2slq5pj;Bseed-2-gang-ED;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43534
   stock_converter_model: TS0012
+  old_zb_models:
+  - Bseed-2-gang-ED
   tuya_manufacturer_names:
   - _TZ3000_f2slq5pj
   - Bseed-2-gang
@@ -248,24 +200,13 @@ BSEED_2_GANG_SWITCH_END_DEVICE:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
 BSEED_2_GANG_SWITCH_2:
   config_str: xk5udnd6;Bseed-2-gang-2;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43544
-  stock_converter_model: TS0012
-  tuya_manufacturer_names:
-  - _TZ3000_xk5udnd6
-  - Bseed-2-gang-2
-  human_name: Bseed TS0012 (2 gang switch)
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
-BSEED_2_GANG_SWITCH_2_END_DEVICE:
-  config_str: xk5udnd6;Bseed-2-gang-2-ED;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43544
   stock_converter_model: TS0012
+  old_zb_models:
+  - Bseed-2-gang-2-ED
   tuya_manufacturer_names:
   - _TZ3000_xk5udnd6
   - Bseed-2-gang-2
@@ -274,50 +215,29 @@ BSEED_2_GANG_SWITCH_2_END_DEVICE:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
 TS0012_AVATTO:
   config_str: ljhbw1c9;TS0012-avatto;BB4f;LB5;SC0f;SC3f;RC2;RC4;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43530
-  stock_converter_model: TS0012_switch_module
-  tuya_manufacturer_names:
-  - _TZ3000_ljhbw1c9
-  - TS0012-Avatto
-  human_name: Avatto TS0012
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
-TS0012_AVATTO_END_DEVICE:
-  config_str: ljhbw1c9;TS0012-avatto-ED;BB4f;LB5;SC0f;SC3f;RC2;RC4;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43530
   stock_converter_model: TS0012_switch_module
+  old_zb_models:
+  - TS0012-avatto-ED
   tuya_manufacturer_names:
   - _TZ3000_ljhbw1c9
   - TS0012-Avatto
   human_name: Avatto TS0012
+  override_z2m_device: LZWSM16-2
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 WHD02_AUBESS:
   config_str: 46t1rvdu;WHD02-Aubess;BC4u;LD2;SB4u;RB5;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43531
-  stock_converter_model: WHD02
-  tuya_manufacturer_names:
-  - _TZ3000_46t1rvdu
-  - WHD02-Aubess
-  human_name: Aubess WHD02
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/18
-WHD02_AUBESS_END_DEVICE:
-  config_str: 46t1rvdu;WHD02-Aubess-ED;BC4u;LD2;SB4u;RB5;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43531
   stock_converter_model: WHD02
+  old_zb_models:
+  - WHD02-Aubess-ED
   tuya_manufacturer_names:
   - _TZ3000_46t1rvdu
   - WHD02-Aubess
@@ -326,26 +246,14 @@ WHD02_AUBESS_END_DEVICE:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/18
 MOES_1_GANG_SWITCH:
   config_str: hhiodade;Moes-1-gang;SC1u;RB5;ID7;M;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43532
-  stock_converter_model: ZS-EUB_1gang
-  stock_converter_manufacturer: moes
-  tuya_manufacturer_names:
-  - _TZ3000_hhiodade
-  - Moes-1-gang
-  human_name: Moes TS0011 (1 gang switch)
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
-MOES_1_GANG_SWITCH_END_DEVICE:
-  config_str: hhiodade;Moes-1-gang-ED;SC1u;RB5;ID7;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43532
   stock_converter_model: ZS-EUB_1gang
   stock_converter_manufacturer: moes
+  old_zb_models:
+  - Moes-1-gang-ED
   tuya_manufacturer_names:
   - _TZ3000_hhiodade
   - Moes-1-gang
@@ -354,24 +262,13 @@ MOES_1_GANG_SWITCH_END_DEVICE:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_3_GANG_SWITCH:
   config_str: qewo8dlz;Moes-3-gang;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43533
-  stock_converter_model: TS0013
-  tuya_manufacturer_names:
-  - _TZ3000_qewo8dlz
-  - Moes-3-gang
-  human_name: Moes TS0013 (3 gang switch)
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
-MOES_3_GANG_SWITCH_END_DEVICE:
-  config_str: qewo8dlz;Moes-3-gang-ED;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43533
   stock_converter_model: TS0013
+  old_zb_models:
+  - Moes-3-gang-ED
   tuya_manufacturer_names:
   - _TZ3000_qewo8dlz
   - Moes-3-gang
@@ -406,24 +303,13 @@ WHD02_3:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/44
 ZEMISMART_2_GANG:
   config_str: zmlunnhy;Zemi-2-gang;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43536
-  stock_converter_model: TS0012
-  tuya_manufacturer_names:
-  - _TZ3000_zmlunnhy
-  - Zemi-2-gang
-  human_name: Internet search says this is Zemismart 2 gang switch, needs confirmation
-  status: In progress
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/19
-ZEMISMART_2_GANG_END_DEVICE:
-  config_str: zmlunnhy;Zemi-2-gang-ED;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43536
   stock_converter_model: TS0012
+  old_zb_models:
+  - Zemi-2-gang-ED
   tuya_manufacturer_names:
   - _TZ3000_zmlunnhy
   - Zemi-2-gang
@@ -432,26 +318,14 @@ ZEMISMART_2_GANG_END_DEVICE:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/19
 TS0011_AVATTO:
   config_str: hbxsdd6k;TS0011-avatto;BB4u;LB5;SC0u;RC2;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43537
-  stock_converter_manufacturer: avatto
-  stock_converter_model: LZWSM16-1
-  tuya_manufacturer_names:
-  - _TZ3000_hbxsdd6k
-  - TS0011-Avatto
-  human_name: Avatto TS0011
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
-TS0011_AVATTO_END_DEVICE:
-  config_str: hbxsdd6k;TS0011-avatto-ED;BB4u;LB5;SC0u;RC2;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43537
   stock_converter_manufacturer: avatto
   stock_converter_model: LZWSM16-1
+  old_zb_models:
+  - TS0011-avatto-ED
   tuya_manufacturer_names:
   - _TZ3000_hbxsdd6k
   - TS0011-Avatto
@@ -502,28 +376,17 @@ TS0004_IHS:
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/105
 TS0013_GIRIER:
   config_str: ypgri8yz;ZB08-custom;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
-  device_type: router
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 43539
-  stock_converter_model: TS0013_switch_module
-  override_z2m_device: ZB08
-  tuya_manufacturer_names:
-  - _TZ3000_ypgri8yz
-  - Girier-ZB08-custom
-  human_name: Girier-ZB08
-  status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/37
-TS0013_GIRIER_END_DEVICE:
-  config_str: ypgri8yz;ZB08-custom-ED;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43539
   stock_converter_model: TS0013_switch_module
   override_z2m_device: ZB08
+  old_zb_models:
+  - ZB08-custom-ED
   tuya_manufacturer_names:
   - _TZ3000_ypgri8yz
+  - Girier-ZB08-custom
   - Girier-ZB08-custom-ED
   human_name: Girier-ZB08
   status: Supported
@@ -564,6 +427,7 @@ AVATTO_3_GANG_TOUCH:
   tuya_manufacturer_names:
   - _TZ3000_avky2mvc
   - Avatto-3-touch
+  # override_z2m_device: 37022474_2
   human_name: Avatto Zigbee 3 Gang (ZTS02RD-US-W3)
   status: WIP, expiremntal, see issue.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/41

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1,5 +1,5 @@
 TS0012:
-  config_str: Tuya-TS0012-custom;TS0012-custom;BA0f;LD7;SC2f;SC3f;RC0;RB4;
+  config_str: jl7qyupf;TS0012-custom;BA0f;LD7;SC2f;SC3f;RC0;RB4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -10,10 +10,11 @@ TS0012:
   tuya_manufacturer_names:
   - _TZ3000_jl7qyupf  # Initial device
   - Tuya-CUSTOM   # Old name from early firmware
+  - Tuya-TS0012-custom
   human_name: GIRIER TS0012, OXT
   status: Supported
 TS0012_END_DEVICE:
-  config_str: Tuya-TS0012-custom;TS0012-custom-end-device;BA0f;LD7;SC2f;SC3f;RC0;RB4;
+  config_str: jl7qyupf;TS0012-custom-end-device;BA0f;LD7;SC2f;SC3f;RC0;RB4;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -23,11 +24,12 @@ TS0012_END_DEVICE:
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
   - _TZ3000_jl7qyupf
-  - Tuya-CUSTOM   # Old name from early firmware
+  - Tuya-CUSTOM
+  - Tuya-TS0012-custom
   human_name: GIRIER TS0012, OXT
   status: Supported
 WHD02:
-  config_str: Tuya-WHD02-custom;WHD02-custom;BB4u;LD3;SB5u;RB1;
+  config_str: skueekg3;WHD02-custom;BB4u;LD3;SB5u;RB1;
   device_type: router
   tuya_manufacturer_id: 4407
   tuya_image_type: 524
@@ -35,10 +37,11 @@ WHD02:
   stock_converter_model: WHD02
   tuya_manufacturer_names:
   - _TZ3000_skueekg3
+  - Tuya-WHD02-custom
   human_name: No-name 1 gang switch
   status: Supported
 TS0002:
-  config_str: Tuya-TS0002-custom;TS0002-custom;BD2u;LC2;SB5u;SB4u;RC4;RC3;
+  config_str: 01gpyda5;TS0002-custom;BD2u;LC2;SB5u;SB4u;RC4;RC3;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -46,11 +49,12 @@ TS0002:
   stock_converter_model: TS0002_basic
   tuya_manufacturer_names:
   - _TZ3000_01gpyda5
+  - Tuya-TS0002-custom
   human_name: OXT TS0001, probably other rebrands
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/6
 TS0002_OXT:
-  config_str: TS0002-OXT-CUS;TS0002-OXT-CUS;BD2u;LC0;SB4u;SB5u;RC2;RC3;
+  config_str: bvrlqyj7;TS0002-OXT-CUS;BD2u;LC0;SB4u;SB5u;RC2;RC3;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -58,11 +62,12 @@ TS0002_OXT:
   stock_converter_model: TS0002_basic
   tuya_manufacturer_names:
   - _TZ3000_bvrlqyj7
+  - TS0002-OXT-CUS
   human_name: OXT 2-gang switch
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/49
 TS0011:
-  config_str: Tuya-TS0011-custom;TS0011-custom;BA0f;LD7;SC2f;RC0;
+  config_str: ji4araar;TS0011-custom;BA0f;LD7;SC2f;RC0;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -70,11 +75,12 @@ TS0011:
   stock_converter_model: TS0011_switch_module
   tuya_manufacturer_names:
   - _TZ3000_ji4araar
+  - Tuya-TS0011-custom
   human_name: GIRIER TS0011, OXT TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/4
 TS0011_END_DEVICE:
-  config_str: Tuya-TS0011-custom;TS0011-custom;BA0f;LD7;SC2f;RC0;
+  config_str: ji4araar;TS0011-custom;BA0f;LD7;SC2f;RC0;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -82,11 +88,12 @@ TS0011_END_DEVICE:
   stock_converter_model: TS0011_switch_module
   tuya_manufacturer_names:
   - _TZ3000_ji4araar
+  - Tuya-TS0011-custom
   human_name: GIRIER TS0011, OXT TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/4
 TS0001:
-  config_str: Tuya-TS0001-custom;TS0001-custom;BD2u;LC0;SB4u;RC2;
+  config_str: tqlv4ug4;TS0001-custom;BD2u;LC0;SB4u;RC2;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -94,11 +101,12 @@ TS0001:
   stock_converter_model: TS0001_switch_module
   tuya_manufacturer_names:
   - _TZ3000_tqlv4ug4
+  - Tuya-TS0001-custom
   human_name: OXT TS0001, probably other rebrands
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/6
 TS0002_GIRIER:
-  config_str: Tuya-TS0002-custom;TS0002-custom;BD2u;LC2;SB5u;RC4;SB4u;RC3;
+  config_str: zmy4lslw;TS0002-custom;BD2u;LC2;SB5u;RC4;SB4u;RC3;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -106,11 +114,12 @@ TS0002_GIRIER:
   stock_converter_model: TS0002_basic
   tuya_manufacturer_names:
   - _TZ3000_zmy4lslw
+  - Tuya-TS0002-custom
   human_name: GIRIER 2 Gang
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/29
 TS0001_AVATTO:
-  config_str: TS0001-AVB;TS0001-AVB;BC2u;LD2i;SD3u;RC0;
+  config_str: 4rbqgcuv;TS0001-AVB;BC2u;LD2i;SD3u;RC0;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -120,6 +129,7 @@ TS0001_AVATTO:
   - _TZ3000_4rbqgcuv
   - Tuya-TS0001-Avatto-custom
   - TS0001-AV-CUS
+  - TS0001-AVB
   old_zb_models:
   - TS0001-Avatto-custom
   - TS0001-AV-CUS
@@ -128,7 +138,7 @@ TS0001_AVATTO:
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
 TS0002_AVATTO:
-  config_str: TS0002-AVB;TS0002-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;
+  config_str: mtnpt6ws;TS0002-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -138,6 +148,7 @@ TS0002_AVATTO:
   - _TZ3000_mtnpt6ws
   - Tuya-TS0002-Avatto-custom
   - TS0002-AV-CUS
+  - TS0002-AVB
   old_zb_models:
   - TS0002-Avatto-custom
   - TS0002-AV-CUS
@@ -146,7 +157,7 @@ TS0002_AVATTO:
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
 TS0003_AVATTO:
-  config_str: TS0003-AVB;TS0003-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;
+  config_str: hbic3ka3;TS0003-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -156,6 +167,7 @@ TS0003_AVATTO:
   - _TZ3000_hbic3ka3
   - Tuya-TS0003-Avatto-custom
   - TS0003-AV-CUS
+  - TS0003-AVB
   old_zb_models:
   - TS0003-Avatto-custom
   - TS0003-AV-CUS
@@ -164,7 +176,7 @@ TS0003_AVATTO:
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/56
 TS0004_AVATTO:
-  config_str: TS0004-AVB;TS0004-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;SA0u;RC4;
+  config_str: 5ajpkyq6;TS0004-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;SA0u;RC4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -174,6 +186,7 @@ TS0004_AVATTO:
   - _TZ3000_5ajpkyq6
   - Tuya-TS0004-Avatto-custom
   - TS0004-AV-CUS
+  - TS0004-AVB
   old_zb_models:
   - TS0004-Avatto-custom
   - TS0004-AV-CUS
@@ -182,7 +195,7 @@ TS0004_AVATTO:
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
 MOES_2_GANG_SWITCH:
-  config_str: Moes-2-gang;Moes-2-gang;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
+  config_str: 18ejxno0;Moes-2-gang;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -190,11 +203,12 @@ MOES_2_GANG_SWITCH:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_18ejxno0
+  - Moes-2-gang
   human_name: Moes TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_2_GANG_SWITCH_END_DEVICE:
-  config_str: Moes-2-gang;Moes-2-gang-ED;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
+  config_str: 18ejxno0;Moes-2-gang-ED;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -202,11 +216,12 @@ MOES_2_GANG_SWITCH_END_DEVICE:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_18ejxno0
+  - Moes-2-gang
   human_name: Moes TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 BSEED_2_GANG_SWITCH:
-  config_str: Bseed-2-gang;Bseed-2-gang;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
+  config_str: f2slq5pj;Bseed-2-gang;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -214,11 +229,12 @@ BSEED_2_GANG_SWITCH:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_f2slq5pj
+  - Bseed-2-gang
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
 BSEED_2_GANG_SWITCH_END_DEVICE:
-  config_str: Bseed-2-gang;Bseed-2-gang-ED;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
+  config_str: f2slq5pj;Bseed-2-gang-ED;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -226,11 +242,12 @@ BSEED_2_GANG_SWITCH_END_DEVICE:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_f2slq5pj
+  - Bseed-2-gang
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
 BSEED_2_GANG_SWITCH_2:
-  config_str: Bseed-2-gang-2;Bseed-2-gang-2;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
+  config_str: xk5udnd6;Bseed-2-gang-2;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -238,11 +255,12 @@ BSEED_2_GANG_SWITCH_2:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_xk5udnd6
+  - Bseed-2-gang-2
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
 BSEED_2_GANG_SWITCH_2_END_DEVICE:
-  config_str: Bseed-2-gang-2;Bseed-2-gang-2-ED;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
+  config_str: xk5udnd6;Bseed-2-gang-2-ED;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -250,11 +268,12 @@ BSEED_2_GANG_SWITCH_2_END_DEVICE:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_xk5udnd6
+  - Bseed-2-gang-2
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
 TS0012_AVATTO:
-  config_str: TS0012-Avatto;TS0012-avatto;BB4f;LB5;SC0f;SC3f;RC2;RC4;
+  config_str: ljhbw1c9;TS0012-avatto;BB4f;LB5;SC0f;SC3f;RC2;RC4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -262,11 +281,12 @@ TS0012_AVATTO:
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
   - _TZ3000_ljhbw1c9
+  - TS0012-Avatto
   human_name: Avatto TS0012
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 TS0012_AVATTO_END_DEVICE:
-  config_str: TS0012-Avatto;TS0012-avatto-ED;BB4f;LB5;SC0f;SC3f;RC2;RC4;
+  config_str: ljhbw1c9;TS0012-avatto-ED;BB4f;LB5;SC0f;SC3f;RC2;RC4;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -274,11 +294,12 @@ TS0012_AVATTO_END_DEVICE:
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
   - _TZ3000_ljhbw1c9
+  - TS0012-Avatto
   human_name: Avatto TS0012
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 WHD02_AUBESS:
-  config_str: WHD02-Aubess;WHD02-Aubess;BC4u;LD2;SB4u;RB5;
+  config_str: 46t1rvdu;WHD02-Aubess;BC4u;LD2;SB4u;RB5;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -286,11 +307,12 @@ WHD02_AUBESS:
   stock_converter_model: WHD02
   tuya_manufacturer_names:
   - _TZ3000_46t1rvdu
+  - WHD02-Aubess
   human_name: Aubess WHD02
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/18
 WHD02_AUBESS_END_DEVICE:
-  config_str: WHD02-Aubess;WHD02-Aubess-ED;BC4u;LD2;SB4u;RB5;
+  config_str: 46t1rvdu;WHD02-Aubess-ED;BC4u;LD2;SB4u;RB5;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -298,11 +320,12 @@ WHD02_AUBESS_END_DEVICE:
   stock_converter_model: WHD02
   tuya_manufacturer_names:
   - _TZ3000_46t1rvdu
+  - WHD02-Aubess
   human_name: Aubess WHD02
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/18
 MOES_1_GANG_SWITCH:
-  config_str: Moes-1-gang;Moes-1-gang;SC1u;RB5;ID7;M;
+  config_str: hhiodade;Moes-1-gang;SC1u;RB5;ID7;M;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -311,11 +334,12 @@ MOES_1_GANG_SWITCH:
   stock_converter_manufacturer: moes
   tuya_manufacturer_names:
   - _TZ3000_hhiodade
+  - Moes-1-gang
   human_name: Moes TS0011 (1 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_1_GANG_SWITCH_END_DEVICE:
-  config_str: Moes-1-gang;Moes-1-gang-ED;SC1u;RB5;ID7;M;
+  config_str: hhiodade;Moes-1-gang-ED;SC1u;RB5;ID7;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -324,11 +348,12 @@ MOES_1_GANG_SWITCH_END_DEVICE:
   stock_converter_manufacturer: moes
   tuya_manufacturer_names:
   - _TZ3000_hhiodade
+  - Moes-1-gang
   human_name: Moes TS0011 (1 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_3_GANG_SWITCH:
-  config_str: Moes-3-gang;Moes-3-gang;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
+  config_str: qewo8dlz;Moes-3-gang;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -336,11 +361,12 @@ MOES_3_GANG_SWITCH:
   stock_converter_model: TS0013
   tuya_manufacturer_names:
   - _TZ3000_qewo8dlz
+  - Moes-3-gang
   human_name: Moes TS0013 (3 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_3_GANG_SWITCH_END_DEVICE:
-  config_str: Moes-3-gang;Moes-3-gang-ED;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
+  config_str: qewo8dlz;Moes-3-gang-ED;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -348,11 +374,12 @@ MOES_3_GANG_SWITCH_END_DEVICE:
   stock_converter_model: TS0013
   tuya_manufacturer_names:
   - _TZ3000_qewo8dlz
+  - Moes-3-gang
   human_name: Moes TS0013 (3 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 WHD02_2:
-  config_str: Tuya-WHD02-custom;WHD02-custom;BB1u;LB4;SD2u;RD3;
+  config_str: skueekg3;WHD02-custom;BB1u;LB4;SD2u;RD3;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -360,11 +387,12 @@ WHD02_2:
   stock_converter_model: WHD02
   tuya_manufacturer_names:
   - _TZ3000_skueekg3
+  - Tuya-WHD02-custom
   human_name: No-name 1 gang switch with no rf shiled ZT2S
   status: In progress, tuya_manufacturer_name is not confirmed
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/24
 WHD02_3:
-  config_str: Tuya-WHD02-custom;WHD02-custom;BB1u;LB4;SD2u;RD3;
+  config_str: skueekg3;WHD02-custom;BB1u;LB4;SD2u;RD3;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 518
@@ -372,11 +400,12 @@ WHD02_3:
   stock_converter_model: WHD02
   tuya_manufacturer_names:
   - _TZ3000_skueekg3
+  - Tuya-WHD02-custom
   human_name: No-name 1 gang switch with no rf shiled ZT2S
   status: In progress, tuya_manufacturer_name is not confirmed
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/44
 ZEMISMART_2_GANG:
-  config_str: Zemi-2-gang;Zemi-2-gang;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
+  config_str: zmlunnhy;Zemi-2-gang;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -384,11 +413,12 @@ ZEMISMART_2_GANG:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_zmlunnhy
+  - Zemi-2-gang
   human_name: Internet search says this is Zemismart 2 gang switch, needs confirmation
   status: In progress
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/19
 ZEMISMART_2_GANG_END_DEVICE:
-  config_str: Zemi-2-gang;Zemi-2-gang-ED;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
+  config_str: zmlunnhy;Zemi-2-gang-ED;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -396,11 +426,12 @@ ZEMISMART_2_GANG_END_DEVICE:
   stock_converter_model: TS0012
   tuya_manufacturer_names:
   - _TZ3000_zmlunnhy
+  - Zemi-2-gang
   human_name: Internet search says this is Zemismart 2 gang switch, needs confirmation
   status: In progress
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/19
 TS0011_AVATTO:
-  config_str: TS0011-Avatto;TS0011-avatto;BB4u;LB5;SC0u;RC2;
+  config_str: hbxsdd6k;TS0011-avatto;BB4u;LB5;SC0u;RC2;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -409,11 +440,12 @@ TS0011_AVATTO:
   stock_converter_model: LZWSM16-1
   tuya_manufacturer_names:
   - _TZ3000_hbxsdd6k
+  - TS0011-Avatto
   human_name: Avatto TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 TS0011_AVATTO_END_DEVICE:
-  config_str: TS0011-Avatto;TS0011-avatto-ED;BB4u;LB5;SC0u;RC2;
+  config_str: hbxsdd6k;TS0011-avatto-ED;BB4u;LB5;SC0u;RC2;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -422,11 +454,12 @@ TS0011_AVATTO_END_DEVICE:
   stock_converter_model: LZWSM16-1
   tuya_manufacturer_names:
   - _TZ3000_hbxsdd6k
+  - TS0011-Avatto
   human_name: Avatto TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 TS0003:
-  config_str: Tuya-TS0003-custom;TS0003-custom;BD3u;SC1u;SD7u;SC3u;RB5;RD4;RB4;
+  config_str: pfc7i3kt;TS0003-custom;BD3u;SC1u;SD7u;SC3u;RB5;RD4;RB4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -434,11 +467,12 @@ TS0003:
   stock_converter_model: TS0003
   tuya_manufacturer_names:
   - _TZ3000_pfc7i3kt
+  - Tuya-TS0003-custom
   human_name: Moes MS-104CZ
   status: Supported
   github_issue: null
 TS0003_IHS:
-  config_str: TS0003-IHS;TS0003-IHS;BC3u;LC2i;SD7u;RD2;SB4u;RD3;SB5u;RC0;
+  config_str: mhhxxjrs;TS0003-IHS;BC3u;LC2i;SD7u;RD2;SB4u;RD3;SB5u;RC0;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -447,13 +481,14 @@ TS0003_IHS:
   tuya_manufacturer_names:
   - _TZ3000_mhhxxjrs
   - TS0003-3CH-cus
+  - TS0003-IHS
   old_zb_models:
   - TS0003-3CH-cus
   human_name: IHSENO 3-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/85
 TS0004_IHS:
-  config_str: TS0004-IHS;TS0004-IHS;BC3u;LC2i;SB5u;RD2;SB4u;RD3;SD7u;RC0;SD4u;RC1;
+  config_str: knoj8lpk;TS0004-IHS;BC3u;LC2i;SB5u;RD2;SB4u;RD3;SD7u;RC0;SD4u;RC1;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -461,11 +496,12 @@ TS0004_IHS:
   stock_converter_model: TS0004_switch_module_2
   tuya_manufacturer_names:
   - _TZ3000_knoj8lpk
+  - TS0004-IHS
   human_name: IHSENO 4-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/105
 TS0013_GIRIER:
-  config_str: Girier-ZB08-custom;ZB08-custom;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
+  config_str: ypgri8yz;ZB08-custom;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -474,11 +510,12 @@ TS0013_GIRIER:
   override_z2m_device: ZB08
   tuya_manufacturer_names:
   - _TZ3000_ypgri8yz
+  - Girier-ZB08-custom
   human_name: Girier-ZB08
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/37
 TS0013_GIRIER_END_DEVICE:
-  config_str: Girier-ZB08-custom-ED;ZB08-custom-ED;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
+  config_str: ypgri8yz;ZB08-custom-ED;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -487,11 +524,12 @@ TS0013_GIRIER_END_DEVICE:
   override_z2m_device: ZB08
   tuya_manufacturer_names:
   - _TZ3000_ypgri8yz
+  - Girier-ZB08-custom-ED
   human_name: Girier-ZB08
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/37
 TS0004_AVATTO_NEUTRAL:
-  config_str: TS0004-Avv;TS0004-Avv;BB5u;LC1;SB4u;RC0;SD2u;RC4;SC3u;RD4;SC2u;RD7;
+  config_str: ltt60asa;TS0004-Avv;BB5u;LC1;SB4u;RC0;SD2u;RC4;SC3u;RD4;SC2u;RD7;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -499,11 +537,12 @@ TS0004_AVATTO_NEUTRAL:
   stock_converter_model: TS0004_switch_module
   tuya_manufacturer_names:
   - _TZ3000_ltt60asa
+  - TS0004-Avv
   human_name: Avatto 4 gang switch module with N
   status: WIP, check issue for current status.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/42
 TS0004:
-  config_str: Tuya-TS0004-custom;TS0004-custom;BB6u;LB1;SC1u;RB7;SC2u;RB5;SC3u;RB4;SD2u;RC4;
+  config_str: mmkbptmx;TS0004-custom;BB6u;LB1;SC1u;RB7;SC2u;RB5;SC3u;RB4;SD2u;RC4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -511,11 +550,12 @@ TS0004:
   stock_converter_model: TS0004_switch_module
   tuya_manufacturer_names:
   - _TZ3000_mmkbptmx
+  - Tuya-TS0004-custom
   human_name: No-name 4 gang switch module with N
   status: Untested
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/66
 AVATTO_3_GANG_TOUCH:
-  config_str: Avatto-3-touch;Avatto-3-touch;LB5;SD3u;RC2;SD7u;RC3;SD4u;RD2;M;
+  config_str: avky2mvc;Avatto-3-touch;LB5;SD3u;RC2;SD7u;RC3;SD4u;RD2;M;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
@@ -523,6 +563,7 @@ AVATTO_3_GANG_TOUCH:
   stock_converter_model: TS0003_switch_3_gang
   tuya_manufacturer_names:
   - _TZ3000_avky2mvc
+  - Avatto-3-touch
   human_name: Avatto Zigbee 3 Gang (ZTS02RD-US-W3)
   status: WIP, expiremntal, see issue.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/41

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1,47 +1,43 @@
 TS0012:
-  name: TS0012-custom
   config_str: Tuya-TS0012-custom;TS0012-custom;BA0f;LD7;SC2f;SC3f;RC0;RB4;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43521
   old_zb_models:
-    - TS0042-CUSTOM
+  - TS0042-CUSTOM
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
-      - _TZ3000_jl7qyupf  # Initial device
-      - Tuya-CUSTOM   # Old name from early firmware
+  - _TZ3000_jl7qyupf  # Initial device
+  - Tuya-CUSTOM   # Old name from early firmware
   human_name: GIRIER TS0012, OXT
   status: Supported
 TS0012_END_DEVICE:
-  name: TS0012-custom-end-device
   config_str: Tuya-TS0012-custom;TS0012-custom-end-device;BA0f;LD7;SC2f;SC3f;RC0;RB4;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43521
   old_zb_models:
-    - TS0042-CUSTOM
+  - TS0042-CUSTOM
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
-    - _TZ3000_jl7qyupf
-    - Tuya-CUSTOM   # Old name from early firmware
+  - _TZ3000_jl7qyupf
+  - Tuya-CUSTOM   # Old name from early firmware
   human_name: GIRIER TS0012, OXT
   status: Supported
 WHD02:
-  name: WHD02-custom
   config_str: Tuya-WHD02-custom;WHD02-custom;BB4u;LD3;SB5u;RB1;
   device_type: router
   tuya_manufacturer_id: 4407
   tuya_image_type: 524
   firmware_image_type: 43522
-  stock_converter_model:  WHD02
+  stock_converter_model: WHD02
   tuya_manufacturer_names:
-    - _TZ3000_skueekg3
+  - _TZ3000_skueekg3
   human_name: No-name 1 gang switch
   status: Supported
 TS0002:
-  name: TS0002-custom
   config_str: Tuya-TS0002-custom;TS0002-custom;BD2u;LC2;SB5u;SB4u;RC4;RC3;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -49,12 +45,11 @@ TS0002:
   firmware_image_type: 43523
   stock_converter_model: TS0002_basic
   tuya_manufacturer_names:
-    - _TZ3000_01gpyda5
+  - _TZ3000_01gpyda5
   human_name: OXT TS0001, probably other rebrands
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/6
 TS0002_OXT:
-  name: OXT_2_GANG
   config_str: TS0002-OXT-CUS;TS0002-OXT-CUS;BD2u;LC0;SB4u;SB5u;RC2;RC3;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -62,12 +57,11 @@ TS0002_OXT:
   firmware_image_type: 43547
   stock_converter_model: TS0002_basic
   tuya_manufacturer_names:
-    - _TZ3000_bvrlqyj7
+  - _TZ3000_bvrlqyj7
   human_name: OXT 2-gang switch
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/49
 TS0011:
-  name: TS0011-custom
   config_str: Tuya-TS0011-custom;TS0011-custom;BA0f;LD7;SC2f;RC0;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -75,12 +69,11 @@ TS0011:
   firmware_image_type: 43524
   stock_converter_model: TS0011_switch_module
   tuya_manufacturer_names:
-    - _TZ3000_ji4araar
+  - _TZ3000_ji4araar
   human_name: GIRIER TS0011, OXT TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/4
 TS0011_END_DEVICE:
-  name: TS0011-custom
   config_str: Tuya-TS0011-custom;TS0011-custom;BA0f;LD7;SC2f;RC0;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -88,12 +81,11 @@ TS0011_END_DEVICE:
   firmware_image_type: 43524
   stock_converter_model: TS0011_switch_module
   tuya_manufacturer_names:
-    - _TZ3000_ji4araar
+  - _TZ3000_ji4araar
   human_name: GIRIER TS0011, OXT TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/4
 TS0001:
-  name: TS0001-custom
   config_str: Tuya-TS0001-custom;TS0001-custom;BD2u;LC0;SB4u;RC2;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -101,12 +93,11 @@ TS0001:
   firmware_image_type: 43525
   stock_converter_model: TS0001_switch_module
   tuya_manufacturer_names:
-      - _TZ3000_tqlv4ug4  # Ok 
+  - _TZ3000_tqlv4ug4
   human_name: OXT TS0001, probably other rebrands
   status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/6  
+  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/6
 TS0002_GIRIER:
-  name: TS0002-custom
   config_str: Tuya-TS0002-custom;TS0002-custom;BD2u;LC2;SB5u;RC4;SB4u;RC3;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -114,12 +105,11 @@ TS0002_GIRIER:
   firmware_image_type: 43526
   stock_converter_model: TS0002_basic
   tuya_manufacturer_names:
-      - _TZ3000_zmy4lslw 
+  - _TZ3000_zmy4lslw
   human_name: GIRIER 2 Gang
   status: Supported
-  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/29 
+  github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/29
 TS0001_AVATTO:
-  name: TS0001-Avatto-custom
   config_str: TS0001-AVB;TS0001-AVB;BC2u;LD2i;SD3u;RC0;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -127,18 +117,17 @@ TS0001_AVATTO:
   firmware_image_type: 43527
   stock_converter_model: TS0001_switch_module
   tuya_manufacturer_names:
-    - _TZ3000_4rbqgcuv
-    - Tuya-TS0001-Avatto-custom
-    - TS0001-AV-CUS
+  - _TZ3000_4rbqgcuv
+  - Tuya-TS0001-Avatto-custom
+  - TS0001-AV-CUS
   old_zb_models:
-    - TS0001-Avatto-custom
-    - TS0001-AV-CUS
+  - TS0001-Avatto-custom
+  - TS0001-AV-CUS
   override_z2m_device: ZWSM16-1-Zigbee
   human_name: AVATTO ZWSM16-1-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
 TS0002_AVATTO:
-  name: TS0002-Avatto-custom
   config_str: TS0002-AVB;TS0002-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -146,18 +135,17 @@ TS0002_AVATTO:
   firmware_image_type: 43528
   stock_converter_model: TS0002_limited
   tuya_manufacturer_names:
-    - _TZ3000_mtnpt6ws
-    - Tuya-TS0002-Avatto-custom
-    - TS0002-AV-CUS
+  - _TZ3000_mtnpt6ws
+  - Tuya-TS0002-Avatto-custom
+  - TS0002-AV-CUS
   old_zb_models:
-    - TS0002-Avatto-custom
-    - TS0002-AV-CUS
+  - TS0002-Avatto-custom
+  - TS0002-AV-CUS
   override_z2m_device: ZWSM16-2-Zigbee
   human_name: AVATTO ZWSM16-2-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
 TS0003_AVATTO:
-  name: TS0003-Avatto-custom
   config_str: TS0003-AVB;TS0003-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -165,18 +153,17 @@ TS0003_AVATTO:
   firmware_image_type: 43543
   stock_converter_model: TS0003_switch_module_2
   tuya_manufacturer_names:
-    - _TZ3000_hbic3ka3
-    - Tuya-TS0003-Avatto-custom
-    - TS0003-AV-CUS
+  - _TZ3000_hbic3ka3
+  - Tuya-TS0003-Avatto-custom
+  - TS0003-AV-CUS
   old_zb_models:
-    - TS0003-Avatto-custom
-    - TS0003-AV-CUS
+  - TS0003-Avatto-custom
+  - TS0003-AV-CUS
   override_z2m_device: ZWSM16-3-Zigbee
   human_name: AVATTO ZWSM16-3-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/56
 TS0004_AVATTO:
-  name: TS0004-Avatto-custom
   config_str: TS0004-AVB;TS0004-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;SA0u;RC4;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -184,18 +171,17 @@ TS0004_AVATTO:
   firmware_image_type: 43529
   stock_converter_model: TS0004_switch_module_2
   tuya_manufacturer_names:
-    - _TZ3000_5ajpkyq6 
-    - Tuya-TS0004-Avatto-custom
-    - TS0004-AV-CUS
+  - _TZ3000_5ajpkyq6
+  - Tuya-TS0004-Avatto-custom
+  - TS0004-AV-CUS
   old_zb_models:
-    - TS0004-Avatto-custom
-    - TS0004-AV-CUS
+  - TS0004-Avatto-custom
+  - TS0004-AV-CUS
   override_z2m_device: ZWSM16-4-Zigbee
   human_name: AVATTO ZWSM16-4-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
 MOES_2_GANG_SWITCH:
-  name: Moes-2-gang
   config_str: Moes-2-gang;Moes-2-gang;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -203,12 +189,11 @@ MOES_2_GANG_SWITCH:
   firmware_image_type: 43510
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-      - _TZ3000_18ejxno0
+  - _TZ3000_18ejxno0
   human_name: Moes TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_2_GANG_SWITCH_END_DEVICE:
-  name: Moes-2-gang
   config_str: Moes-2-gang;Moes-2-gang-ED;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -216,12 +201,11 @@ MOES_2_GANG_SWITCH_END_DEVICE:
   firmware_image_type: 43510
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-      - _TZ3000_18ejxno0
+  - _TZ3000_18ejxno0
   human_name: Moes TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 BSEED_2_GANG_SWITCH:
-  name: Bseed-2-gang
   config_str: Bseed-2-gang;Bseed-2-gang;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -229,12 +213,11 @@ BSEED_2_GANG_SWITCH:
   firmware_image_type: 43534
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-      - _TZ3000_f2slq5pj
+  - _TZ3000_f2slq5pj
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
 BSEED_2_GANG_SWITCH_END_DEVICE:
-  name: Bseed-2-gang
   config_str: Bseed-2-gang;Bseed-2-gang-ED;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -242,12 +225,11 @@ BSEED_2_GANG_SWITCH_END_DEVICE:
   firmware_image_type: 43534
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-      - _TZ3000_f2slq5pj
+  - _TZ3000_f2slq5pj
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/pull/23
 BSEED_2_GANG_SWITCH_2:
-  name: Bseed-2-gang-2
   config_str: Bseed-2-gang-2;Bseed-2-gang-2;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -255,12 +237,11 @@ BSEED_2_GANG_SWITCH_2:
   firmware_image_type: 43544
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-      - _TZ3000_xk5udnd6
+  - _TZ3000_xk5udnd6
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
 BSEED_2_GANG_SWITCH_2_END_DEVICE:
-  name: Bseed-2-gang-2
   config_str: Bseed-2-gang-2;Bseed-2-gang-2-ED;SB5u;SD4u;RC0B6;RA1D7;ID2;ID3;LC3;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -268,12 +249,11 @@ BSEED_2_GANG_SWITCH_2_END_DEVICE:
   firmware_image_type: 43544
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-      - _TZ3000_xk5udnd6
+  - _TZ3000_xk5udnd6
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
 TS0012_AVATTO:
-  name: TS0012-custom
   config_str: TS0012-Avatto;TS0012-avatto;BB4f;LB5;SC0f;SC3f;RC2;RC4;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -281,12 +261,11 @@ TS0012_AVATTO:
   firmware_image_type: 43530
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
-      - _TZ3000_ljhbw1c9 
+  - _TZ3000_ljhbw1c9
   human_name: Avatto TS0012
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 TS0012_AVATTO_END_DEVICE:
-  name: TS0012-custom
   config_str: TS0012-Avatto;TS0012-avatto-ED;BB4f;LB5;SC0f;SC3f;RC2;RC4;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -294,38 +273,35 @@ TS0012_AVATTO_END_DEVICE:
   firmware_image_type: 43530
   stock_converter_model: TS0012_switch_module
   tuya_manufacturer_names:
-      - _TZ3000_ljhbw1c9
+  - _TZ3000_ljhbw1c9
   human_name: Avatto TS0012
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 WHD02_AUBESS:
-  name: WHD02-AUBESS-custom
   config_str: WHD02-Aubess;WHD02-Aubess;BC4u;LD2;SB4u;RB5;
   device_type: router
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43531
-  stock_converter_model:  WHD02
+  stock_converter_model: WHD02
   tuya_manufacturer_names:
-    - _TZ3000_46t1rvdu
+  - _TZ3000_46t1rvdu
   human_name: Aubess WHD02
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/18
 WHD02_AUBESS_END_DEVICE:
-  name: WHD02-AUBESS-custom
   config_str: WHD02-Aubess;WHD02-Aubess-ED;BC4u;LD2;SB4u;RB5;
   device_type: end_device
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 43531
-  stock_converter_model:  WHD02
+  stock_converter_model: WHD02
   tuya_manufacturer_names:
-    - _TZ3000_46t1rvdu  
+  - _TZ3000_46t1rvdu
   human_name: Aubess WHD02
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/18
 MOES_1_GANG_SWITCH:
-  name: Moes-1-gang
   config_str: Moes-1-gang;Moes-1-gang;SC1u;RB5;ID7;M;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -334,12 +310,11 @@ MOES_1_GANG_SWITCH:
   stock_converter_model: ZS-EUB_1gang
   stock_converter_manufacturer: moes
   tuya_manufacturer_names:
-      - _TZ3000_hhiodade
+  - _TZ3000_hhiodade
   human_name: Moes TS0011 (1 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_1_GANG_SWITCH_END_DEVICE:
-  name: Moes-1-gang
   config_str: Moes-1-gang;Moes-1-gang-ED;SC1u;RB5;ID7;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -348,12 +323,11 @@ MOES_1_GANG_SWITCH_END_DEVICE:
   stock_converter_model: ZS-EUB_1gang
   stock_converter_manufacturer: moes
   tuya_manufacturer_names:
-      - _TZ3000_hhiodade
+  - _TZ3000_hhiodade
   human_name: Moes TS0011 (1 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_3_GANG_SWITCH:
-  name: Moes-3-gang
   config_str: Moes-3-gang;Moes-3-gang;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -361,12 +335,11 @@ MOES_3_GANG_SWITCH:
   firmware_image_type: 43533
   stock_converter_model: TS0013
   tuya_manufacturer_names:
-      - _TZ3000_qewo8dlz
+  - _TZ3000_qewo8dlz
   human_name: Moes TS0013 (3 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 MOES_3_GANG_SWITCH_END_DEVICE:
-  name: Moes-3-gang
   config_str: Moes-3-gang;Moes-3-gang-ED;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -374,12 +347,11 @@ MOES_3_GANG_SWITCH_END_DEVICE:
   firmware_image_type: 43533
   stock_converter_model: TS0013
   tuya_manufacturer_names:
-      - _TZ3000_qewo8dlz
+  - _TZ3000_qewo8dlz
   human_name: Moes TS0013 (3 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
 WHD02_2:
-  name: WHD02-custom
   config_str: Tuya-WHD02-custom;WHD02-custom;BB1u;LB4;SD2u;RD3;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -387,12 +359,11 @@ WHD02_2:
   firmware_image_type: 43535
   stock_converter_model: WHD02
   tuya_manufacturer_names:
-    - _TZ3000_skueekg3
+  - _TZ3000_skueekg3
   human_name: No-name 1 gang switch with no rf shiled ZT2S
   status: In progress, tuya_manufacturer_name is not confirmed
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/24
 WHD02_3:
-  name: WHD02-custom
   config_str: Tuya-WHD02-custom;WHD02-custom;BB1u;LB4;SD2u;RD3;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -400,12 +371,11 @@ WHD02_3:
   firmware_image_type: 43541
   stock_converter_model: WHD02
   tuya_manufacturer_names:
-    - _TZ3000_skueekg3
+  - _TZ3000_skueekg3
   human_name: No-name 1 gang switch with no rf shiled ZT2S
   status: In progress, tuya_manufacturer_name is not confirmed
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/44
 ZEMISMART_2_GANG:
-  name: Zemismart-2-gang
   config_str: Zemi-2-gang;Zemi-2-gang;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -413,12 +383,11 @@ ZEMISMART_2_GANG:
   firmware_image_type: 43536
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-    - _TZ3000_zmlunnhy
+  - _TZ3000_zmlunnhy
   human_name: Internet search says this is Zemismart 2 gang switch, needs confirmation
   status: In progress
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/19
 ZEMISMART_2_GANG_END_DEVICE:
-  name: Zemismart-2-gang
   config_str: Zemi-2-gang;Zemi-2-gang-ED;SC3U;SD2U;IB7;ID7;RB5C4;RC2D4;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -426,12 +395,11 @@ ZEMISMART_2_GANG_END_DEVICE:
   firmware_image_type: 43536
   stock_converter_model: TS0012
   tuya_manufacturer_names:
-    - _TZ3000_zmlunnhy
+  - _TZ3000_zmlunnhy
   human_name: Internet search says this is Zemismart 2 gang switch, needs confirmation
   status: In progress
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/19
 TS0011_AVATTO:
-  name: TS0011-custom
   config_str: TS0011-Avatto;TS0011-avatto;BB4u;LB5;SC0u;RC2;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -440,12 +408,11 @@ TS0011_AVATTO:
   stock_converter_manufacturer: avatto
   stock_converter_model: LZWSM16-1
   tuya_manufacturer_names:
-      - _TZ3000_hbxsdd6k 
+  - _TZ3000_hbxsdd6k
   human_name: Avatto TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 TS0011_AVATTO_END_DEVICE:
-  name: TS0011-custom
   config_str: TS0011-Avatto;TS0011-avatto-ED;BB4u;LB5;SC0u;RC2;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -454,12 +421,11 @@ TS0011_AVATTO_END_DEVICE:
   stock_converter_manufacturer: avatto
   stock_converter_model: LZWSM16-1
   tuya_manufacturer_names:
-      - _TZ3000_hbxsdd6k
+  - _TZ3000_hbxsdd6k
   human_name: Avatto TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
 TS0003:
-  name: TS0003-custom
   config_str: Tuya-TS0003-custom;TS0003-custom;BD3u;SC1u;SD7u;SC3u;RB5;RD4;RB4;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -467,12 +433,11 @@ TS0003:
   firmware_image_type: 43538
   stock_converter_model: TS0003
   tuya_manufacturer_names:
-    - _TZ3000_pfc7i3kt
+  - _TZ3000_pfc7i3kt
   human_name: Moes MS-104CZ
   status: Supported
-  github_issue:
+  github_issue: null
 TS0003_IHS:
-  name: TS0003-IHS
   config_str: TS0003-IHS;TS0003-IHS;BC3u;LC2i;SD7u;RD2;SB4u;RD3;SB5u;RC0;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -480,15 +445,14 @@ TS0003_IHS:
   firmware_image_type: 43546
   stock_converter_model: TS0003_switch_module_2
   tuya_manufacturer_names:
-    - _TZ3000_mhhxxjrs
-    - TS0003-3CH-cus
+  - _TZ3000_mhhxxjrs
+  - TS0003-3CH-cus
   old_zb_models:
-    - TS0003-3CH-cus
+  - TS0003-3CH-cus
   human_name: IHSENO 3-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/85
 TS0004_IHS:
-  name: TS0004-IHS
   config_str: TS0004-IHS;TS0004-IHS;BC3u;LC2i;SB5u;RD2;SB4u;RD3;SD7u;RC0;SD4u;RC1;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -496,12 +460,11 @@ TS0004_IHS:
   firmware_image_type: 43548
   stock_converter_model: TS0004_switch_module_2
   tuya_manufacturer_names:
-    - _TZ3000_knoj8lpk
+  - _TZ3000_knoj8lpk
   human_name: IHSENO 4-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/105
 TS0013_GIRIER:
-  name: Girier-ZB08-custom
   config_str: Girier-ZB08-custom;ZB08-custom;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -510,12 +473,11 @@ TS0013_GIRIER:
   stock_converter_model: TS0013_switch_module
   override_z2m_device: ZB08
   tuya_manufacturer_names:
-    - _TZ3000_ypgri8yz
+  - _TZ3000_ypgri8yz
   human_name: Girier-ZB08
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/37
 TS0013_GIRIER_END_DEVICE:
-  name: Girier-ZB08-custom
   config_str: Girier-ZB08-custom-ED;ZB08-custom-ED;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
   device_type: end_device
   tuya_manufacturer_id: 4417
@@ -524,12 +486,11 @@ TS0013_GIRIER_END_DEVICE:
   stock_converter_model: TS0013_switch_module
   override_z2m_device: ZB08
   tuya_manufacturer_names:
-    - _TZ3000_ypgri8yz
+  - _TZ3000_ypgri8yz
   human_name: Girier-ZB08
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/37
 TS0004_AVATTO_NEUTRAL:
-  name: TS0004-Avv
   config_str: TS0004-Avv;TS0004-Avv;BB5u;LC1;SB4u;RC0;SD2u;RC4;SC3u;RD4;SC2u;RD7;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -537,12 +498,11 @@ TS0004_AVATTO_NEUTRAL:
   firmware_image_type: 43540
   stock_converter_model: TS0004_switch_module
   tuya_manufacturer_names:
-    - _TZ3000_ltt60asa
+  - _TZ3000_ltt60asa
   human_name: Avatto 4 gang switch module with N
   status: WIP, check issue for current status.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/42
 TS0004:
-  name: TS0004-custom
   config_str: Tuya-TS0004-custom;TS0004-custom;BB6u;LB1;SC1u;RB7;SC2u;RB5;SC3u;RB4;SD2u;RC4;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -550,12 +510,11 @@ TS0004:
   firmware_image_type: 43545
   stock_converter_model: TS0004_switch_module
   tuya_manufacturer_names:
-    - _TZ3000_mmkbptmx
+  - _TZ3000_mmkbptmx
   human_name: No-name 4 gang switch module with N
   status: Untested
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/66
 AVATTO_3_GANG_TOUCH:
-  name: Avatto-3-gang-touch
   config_str: Avatto-3-touch;Avatto-3-touch;LB5;SD3u;RC2;SD7u;RC3;SD4u;RD2;M;
   device_type: router
   tuya_manufacturer_id: 4417
@@ -563,7 +522,7 @@ AVATTO_3_GANG_TOUCH:
   firmware_image_type: 43542
   stock_converter_model: TS0003_switch_3_gang
   tuya_manufacturer_names:
-      - _TZ3000_avky2mvc
+  - _TZ3000_avky2mvc
   human_name: Avatto Zigbee 3 Gang (ZTS02RD-US-W3)
   status: WIP, expiremntal, see issue.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/41

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -93,6 +93,7 @@ TS0002_GIRIER:
   human_name: GIRIER 2 Gang
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/29
+  store: https://www.aliexpress.com/item/1005006084763437.html
 TS0001_AVATTO:
   config_str: 4rbqgcuv;TS0001-AVB;BC2u;LD2i;SD3u;RC0;
   device_type: router
@@ -113,6 +114,7 @@ TS0001_AVATTO:
   human_name: AVATTO ZWSM16-1-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
+  store: https://www.aliexpress.com/item/1005007247647375.html
 TS0002_AVATTO:
   config_str: mtnpt6ws;TS0002-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;
   device_type: router
@@ -133,6 +135,7 @@ TS0002_AVATTO:
   human_name: AVATTO ZWSM16-2-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
+  store: https://www.aliexpress.com/item/1005007247647375.html
 TS0003_AVATTO:
   config_str: hbic3ka3;TS0003-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;
   device_type: router
@@ -153,6 +156,7 @@ TS0003_AVATTO:
   human_name: AVATTO ZWSM16-3-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/56
+  store: https://www.aliexpress.com/item/1005007247647375.html
 TS0004_AVATTO:
   config_str: 5ajpkyq6;TS0004-AVB;BC2u;LD2i;SD3u;RC0;SD7u;RD4;SB6u;RC1;SA0u;RC4;
   device_type: router
@@ -173,6 +177,7 @@ TS0004_AVATTO:
   human_name: AVATTO ZWSM16-4-Zigbee (blue socket)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/9
+  store: https://www.aliexpress.com/item/1005007247647375.html
 MOES_2_GANG_SWITCH:
   config_str: 18ejxno0;Moes-2-gang;SB6u;SC4u;RB5;RB4;ID3;IC0;M;
   device_type: end_device
@@ -190,6 +195,7 @@ MOES_2_GANG_SWITCH:
   human_name: Moes TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
+  store: https://www.aliexpress.com/item/1005005178075186.html
 BSEED_2_GANG_SWITCH:
   config_str: f2slq5pj;Bseed-2-gang;SB6u;SA1u;RD3;RC0;IC2;IB4;M;
   device_type: end_device
@@ -222,6 +228,7 @@ BSEED_2_GANG_SWITCH_2:
   human_name: Bseed TS0012 (2 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/51
+  store: https://www.aliexpress.com/item/1005003324697513.html
 TS0012_AVATTO:
   config_str: ljhbw1c9;TS0012-avatto;BB4f;LB5;SC0f;SC3f;RC2;RC4;
   device_type: end_device
@@ -239,6 +246,7 @@ TS0012_AVATTO:
   override_z2m_device: LZWSM16-2
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
+  store: https://www.aliexpress.com/item/1005007247647375.html
 WHD02_AUBESS:
   config_str: 46t1rvdu;WHD02-Aubess;BC4u;LD2;SB4u;RB5;
   device_type: end_device
@@ -272,6 +280,7 @@ MOES_1_GANG_SWITCH:
   human_name: Moes TS0011 (1 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
+  store: https://www.aliexpress.com/item/1005005178075186.html
 MOES_3_GANG_SWITCH:
   config_str: qewo8dlz;Moes-3-gang;SB6u;RB5;ID3;SC1u;RB4;ID7;SC4u;RD2;IC0;M;
   device_type: end_device
@@ -288,6 +297,7 @@ MOES_3_GANG_SWITCH:
   human_name: Moes TS0013 (3 gang switch)
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/14
+  store: https://www.aliexpress.com/item/1005005178075186.html
 WHD02_2:
   config_str: skueekg3;WHD02-custom;BB1u;LB4;SD2u;RD3;
   device_type: router
@@ -349,6 +359,7 @@ TS0011_AVATTO:
   human_name: Avatto TS0011
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/16
+  store: https://www.aliexpress.com/item/1005007247647375.html
 TS0003:
   config_str: pfc7i3kt;TS0003-custom;BD3u;SC1u;SD7u;SC3u;RB5;RD4;RB4;
   device_type: router
@@ -379,6 +390,7 @@ TS0003_IHS:
   human_name: IHSENO 3-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/85
+  store: https://www.aliexpress.com/item/1005008107698143.html
 TS0004_IHS:
   config_str: knoj8lpk;TS0004-IHS;BC3u;LC2i;SB5u;RD2;SB4u;RD3;SD7u;RC0;SD4u;RC1;
   device_type: router
@@ -393,6 +405,7 @@ TS0004_IHS:
   human_name: IHSENO 4-gang Neutral
   status: Supported
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/105
+  store: https://www.aliexpress.com/item/1005008107698143.html
 TS0013_GIRIER:
   config_str: ypgri8yz;ZB08-custom;BA0u;LD7;SC2u;RC0;SC3u;RB4;SD2u;RB5;
   device_type: end_device
@@ -439,6 +452,7 @@ TS0004:
   human_name: No-name 4 gang switch module with N
   status: Untested
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/66
+  store: https://www.aliexpress.com/item/1005005748264739.html
 AVATTO_3_GANG_TOUCH:
   config_str: avky2mvc;Avatto-3-touch;LB5;SD3u;RC2;SD7u;RC3;SD4u;RD2;M;
   device_type: router
@@ -454,3 +468,4 @@ AVATTO_3_GANG_TOUCH:
   human_name: Avatto Zigbee 3 Gang (ZTS02RD-US-W3)
   status: WIP, expiremntal, see issue.
   github_issue: https://github.com/romasku/tuya-zigbee-switch/issues/41
+  store: https://www.aliexpress.com/item/1005007097427150.html

--- a/helper_scripts/make_readme.py
+++ b/helper_scripts/make_readme.py
@@ -37,8 +37,8 @@ if __name__ == "__main__":
                 "device_types": [device["device_type"]],
                 "z2m_device": device.get("override_z2m_device") or device["stock_converter_model"]
             }
-        else:
-             by_manufacturer_names[manufacturer_name]["device_types"].append(device["device_type"])
+        if (device["device_type"] == "end_device"):
+             by_manufacturer_names[manufacturer_name]["device_types"].append("router")
 
     for device in by_manufacturer_names.values():
         device["device_types"] = sorted(list(set(device["device_types"])), reverse=True)

--- a/helper_scripts/make_readme.py
+++ b/helper_scripts/make_readme.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     by_manufacturer_names = {}
 
     for device in devices:
-        manufacturer_name = next(name for name in device["tuya_manufacturer_names"] if name.startswith("_TZ3000"))
+        manufacturer_name = device["tuya_manufacturer_name"]
         if manufacturer_name not in by_manufacturer_names:
             by_manufacturer_names[manufacturer_name] = {
                 **device,

--- a/helper_scripts/make_z2m_custom_converters.py
+++ b/helper_scripts/make_z2m_custom_converters.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
 
         devices.append({
             "zb_models": [zb_model, *device.get("old_zb_models", [])],
-            "model": device["stock_converter_model"],
+            "model": device.get("override_z2m_device", device["stock_converter_model"]),
             "switchNames": switch_names,
             "relayNames": relay_names,
             "relayIndicatorNames": relay_names[:indicators_cnt],

--- a/helper_scripts/make_z2m_ota_index.py
+++ b/helper_scripts/make_z2m_ota_index.py
@@ -111,7 +111,9 @@ if __name__ == "__main__":
     manufacturer_names = []
     device = db.get(args.board)
     if device:
-        manufacturer_names.extend(device["tuya_manufacturer_names"])
+        manufacturer_names.append(device["tuya_manufacturer_name"])
+        if "old_manufacturer_names" in device:
+            manufacturer_names.extend(device["old_manufacturer_names"])
         manufacturer_names.append(
             device["config_str"].split(";")[0]
         )

--- a/make_scripts/make_all.sh
+++ b/make_scripts/make_all.sh
@@ -4,7 +4,7 @@
 #   with up to 16 parallel jobs (-j16) for faster compilation.
 # Updates indexes, converters, quirks, and readme.
 
-# Estimated runtime: 5 mins
+# Estimated runtime: 1-5 mins
 
 # Requires dependencies, sdk and toolchain.
 #   Get them by runnnig make_install.sh.
@@ -20,8 +20,14 @@ echo [] > zigbee2mqtt/ota/index_end_device.json
 echo [] > zigbee2mqtt/ota/index_router-FORCE.json 
 echo [] > zigbee2mqtt/ota/index_end_device-FORCE.json 
 
-yq -r '(keys)[]' device_db.yaml | while read ITER; do
-    BOARD=$ITER make clean && BOARD=$ITER make -j16
+yq -r 'to_entries | sort_by(.key)[] | "\(.key) \(.value.device_type)"' device_db.yaml | while read ITER TYPE; do
+  # Always build router firmware
+  BOARD=$ITER DEVICE_TYPE=router make clean && BOARD=$ITER DEVICE_TYPE=router make -j16
+
+  # Also build end_device firmware for devices without Neutral
+  if [ "$TYPE" = "end_device" ]; then
+    BOARD=${ITER} DEVICE_TYPE=end_device make clean && BOARD=${ITER} DEVICE_TYPE=end_device make -j16
+  fi
 done
 
 make update_converters

--- a/zigbee2mqtt/converters/switch_custom.js
+++ b/zigbee2mqtt/converters/switch_custom.js
@@ -505,7 +505,7 @@ const definitions = [
             "TS0001-Avatto-custom",
             "TS0001-AV-CUS",
         ],
-        model: "TS0001_switch_module",
+        model: "ZWSM16-1-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -538,7 +538,7 @@ const definitions = [
             "TS0002-Avatto-custom",
             "TS0002-AV-CUS",
         ],
-        model: "TS0002_limited",
+        model: "ZWSM16-2-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -584,7 +584,7 @@ const definitions = [
             "TS0003-Avatto-custom",
             "TS0003-AV-CUS",
         ],
-        model: "TS0003_switch_module_2",
+        model: "ZWSM16-3-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -643,7 +643,7 @@ const definitions = [
             "TS0004-Avatto-custom",
             "TS0004-AV-CUS",
         ],
-        model: "TS0004_switch_module_2",
+        model: "ZWSM16-4-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -1737,7 +1737,7 @@ const definitions = [
         zigbeeModel: [
             "ZB08-custom",
         ],
-        model: "TS0013_switch_module",
+        model: "ZB08",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -1794,7 +1794,7 @@ const definitions = [
         zigbeeModel: [
             "ZB08-custom-ED",
         ],
-        model: "TS0013_switch_module",
+        model: "ZB08",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [

--- a/zigbee2mqtt/converters_v1/switch_custom.js
+++ b/zigbee2mqtt/converters_v1/switch_custom.js
@@ -506,7 +506,7 @@ const definitions = [
             "TS0001-Avatto-custom",
             "TS0001-AV-CUS",
         ],
-        model: "TS0001_switch_module",
+        model: "ZWSM16-1-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -539,7 +539,7 @@ const definitions = [
             "TS0002-Avatto-custom",
             "TS0002-AV-CUS",
         ],
-        model: "TS0002_limited",
+        model: "ZWSM16-2-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -585,7 +585,7 @@ const definitions = [
             "TS0003-Avatto-custom",
             "TS0003-AV-CUS",
         ],
-        model: "TS0003_switch_module_2",
+        model: "ZWSM16-3-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -644,7 +644,7 @@ const definitions = [
             "TS0004-Avatto-custom",
             "TS0004-AV-CUS",
         ],
-        model: "TS0004_switch_module_2",
+        model: "ZWSM16-4-Zigbee",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -1738,7 +1738,7 @@ const definitions = [
         zigbeeModel: [
             "ZB08-custom",
         ],
-        model: "TS0013_switch_module",
+        model: "ZB08",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [
@@ -1795,7 +1795,7 @@ const definitions = [
         zigbeeModel: [
             "ZB08-custom-ED",
         ],
-        model: "TS0013_switch_module",
+        model: "ZB08",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [


### PR DESCRIPTION
I am working on cleaning the database as discussed in #110:
- [x] show correct Z2M model and picture with the rebranded model names (overwrite with whiteLabel)
- [x] remove duplicate name (the name field is not used anywhere, we already have the name in the key and in the human_name field)
- [ ] automate some processes so we minimize the information needed in the database (eg. get the whiteLabels from original Z2M converters)
- [x] use original manufacturer name in the custom firmware so we keep a reference to the original device
- [ ] ~~standardize the converters and reuse them~~
- [x] add Zigbee board in the database (ZTU, ZT3L etc) - seems useful, I would use it in the converters to prevent impossible pinouts
- [x] add AliExpress link in the db?
- [x] split `tuya_manufacturer_names` into tuya name and old fw names
- [x] combine router and end_device entries

I will do each task in a separate commit so it's easier to review