### PR TITLE
Fix Moes switch 1gang name and icon in Zigbee2mqtt

### DIFF
--- a/zigbee2mqtt/converters/switch_custom.js
+++ b/zigbee2mqtt/converters/switch_custom.js
@@ -1576,7 +1576,7 @@ const definitions = [
             "Moes-1-gang",
             "Moes-1-gang-ED",
         ],
-        model: "None",
+        model: "ZS-EUB_1gang",
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [

--- a/zigbee2mqtt/converters_v1/switch_custom.js
+++ b/zigbee2mqtt/converters_v1/switch_custom.js
@@ -1577,7 +1577,7 @@ const definitions = [
             "Moes-1-gang",
             "Moes-1-gang-ED",
         ],
-        model: "None",
+        model: "ZS-EUB_1gang,
         vendor: "Tuya-custom",
         description: "Custom switch (https://github.com/romasku/tuya-zigbee-switch)",
         extend: [


### PR DESCRIPTION
There was change in recent commin to Zigbee2mqtt converters. Fix name & icon for MOES switch 1gang