### PR TITLE
✨ Add detached relay mode

### DIFF
--- a/docs/changelog_fw.md
+++ b/docs/changelog_fw.md
@@ -6,6 +6,8 @@
 
 ### New features:
 
+- **Detached relay mode:** Detach physical relay from its virtual state
+
 ## v1.1.0:
 
 This release doesn't bring new features, but contains substantial refactoring and

--- a/helper_scripts/templates/switch_custom.js.jinja
+++ b/helper_scripts/templates/switch_custom.js.jinja
@@ -127,6 +127,15 @@ const romasku = {
             description: "State of the relay indicator LED",
             access: "ALL",
         }),
+    relayDetachedMode: (name, endpointName) =>
+        enumLookup({
+            name,
+            endpointName,
+            lookup: { attached: 0, detached: 1 },
+            cluster: "genOnOff",
+            attribute: { ID: 0xff03, type: 0x10 }, // Boolean
+            description: "Detach physical relay from its virtual state (Option ignored by power-on behavior)",
+        }),
     networkIndicator: (name, endpointName) =>
         binary({
             name,
@@ -223,6 +232,9 @@ const definitions = [
             {% for relayName in device.relayIndicatorNames %}
             romasku.relayIndicatorMode("{{relayName}}_indicator_mode", "{{relayName}}"),
             romasku.relayIndicator("{{relayName}}_indicator", "{{relayName}}"),
+            {% endfor %}
+            {% for relayName in device.relayNames %}
+            romasku.relayDetachedMode("{{relayName}}_detached_mode", "{{relayName}}"),
             {% endfor %}
         ],
         meta: { multiEndpoint: true },

--- a/src/base_components/relay.c
+++ b/src/base_components/relay.c
@@ -1,14 +1,17 @@
 #include "relay.h"
 #include "hal/printf_selector.h"
 #include <stddef.h>
+#include <stdbool.h>
 
-void relay_init(relay_t *relay) { relay_off(relay); }
+void relay_init(relay_t *relay) { relay_off(relay, false); }
 
-void relay_on(relay_t *relay) {
+void relay_on(relay_t *relay, bool detached) {
   printf("relay_on\r\n");
-  hal_gpio_write(relay->pin, relay->on_high);
-  if (relay->off_pin) {
-    hal_gpio_write(relay->off_pin, !relay->on_high);
+  if (!detached) {
+    hal_gpio_write(relay->pin, relay->on_high);
+    if (relay->off_pin) {
+      hal_gpio_write(relay->off_pin, !relay->on_high);
+    }
   }
   relay->on = 1;
   if (relay->on_change != NULL) {
@@ -16,11 +19,13 @@ void relay_on(relay_t *relay) {
   }
 }
 
-void relay_off(relay_t *relay) {
+void relay_off(relay_t *relay, bool detached) {
   printf("relay_off\r\n");
-  hal_gpio_write(relay->pin, !relay->on_high);
-  if (relay->off_pin) {
-    hal_gpio_write(relay->off_pin, relay->on_high);
+  if (!detached) {
+    hal_gpio_write(relay->pin, !relay->on_high);
+    if (relay->off_pin) {
+      hal_gpio_write(relay->off_pin, relay->on_high);
+    }
   }
   relay->on = 0;
   if (relay->on_change != NULL) {
@@ -28,11 +33,11 @@ void relay_off(relay_t *relay) {
   }
 }
 
-void relay_toggle(relay_t *relay) {
+void relay_toggle(relay_t *relay, bool detached) {
   printf("relay_toggle\r\n");
   if (relay->on) {
-    relay_off(relay);
+    relay_off(relay, detached);
   } else {
-    relay_on(relay);
+    relay_on(relay, detached);
   }
 }

--- a/src/base_components/relay.h
+++ b/src/base_components/relay.h
@@ -3,6 +3,7 @@
 
 #include "hal/gpio.h"
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef void (*ev_relay_callback_t)(void *, uint8_t);
 
@@ -25,22 +26,25 @@ void relay_init(relay_t *relay);
 /**
  * @brief      Enable the relay
  * @param	   *relay - Relay to use
+ * @param      detached - do not change physical state
  * @return     none
  */
-void relay_on(relay_t *relay);
+void relay_on(relay_t *relay, bool detached);
 
 /**
  * @brief      Disable the relay
  * @param	   *relay - Relay to use
+ * @param      detached - do not change physical state
  * @return     none
  */
-void relay_off(relay_t *relay);
+void relay_off(relay_t *relay, bool detached);
 
 /**
  * @brief      Toggle the relay
  * @param	   *relay - Relay to use
+ * @param      detached - do not change physical state
  * @return     none
  */
-void relay_toggle(relay_t *relay);
+void relay_toggle(relay_t *relay, bool detached);
 
 #endif

--- a/src/device_config/config_parser.c
+++ b/src/device_config/config_parser.c
@@ -171,6 +171,7 @@ void parse_config() {
 
       relay_clusters[relay_clusters_cnt].relay_idx = relay_clusters_cnt;
       relay_clusters[relay_clusters_cnt].relay = &relays[relays_cnt];
+      relay_clusters[relay_clusters_cnt].detached_mode = ZCL_ONOFF_RELAY_MODE_ATTACHED;
 
       relays_cnt++;
       relay_clusters_cnt++;

--- a/src/zigbee/consts.h
+++ b/src/zigbee/consts.h
@@ -49,6 +49,8 @@
 #define ZCL_ATTR_ONOFF_INDICATOR_MODE                   0xff01
 #define ZCL_ATTR_ONOFF_INDICATOR_STATE                  0xff02
 
+#define ZCL_ATTR_ONOFF_DETACHED_RELAY_MODE              0xff03  //todo: setup attribute + nv + zha
+
 // OnOff configuration cluster
 
 #define ZCL_ATTR_ONOFF_CONFIGURATION_SWITCH_TYPE                  0x0000
@@ -99,6 +101,9 @@
 #define ZCL_ONOFF_INDICATOR_MODE_SAME                   0x00
 #define ZCL_ONOFF_INDICATOR_MODE_OPPOSITE               0x01
 #define ZCL_ONOFF_INDICATOR_MODE_MANUAL                 0x02
+
+#define ZCL_ONOFF_RELAY_MODE_ATTACHED                   0x00 //todo: setup attribute + nv + zha
+#define ZCL_ONOFF_RELAY_MODE_DETACHED                   0x01 //todo: setup attribute + nv + zha
 
 // OnOff configuration cluster
 

--- a/src/zigbee/relay_cluster.c
+++ b/src/zigbee/relay_cluster.c
@@ -4,6 +4,7 @@
 #include "device_config/nvm_items.h"
 #include "hal/nvm.h"
 #include "hal/printf_selector.h"
+#include <stdbool.h>
 
 hal_zigbee_cmd_result_t relay_cluster_callback(zigbee_relay_cluster *cluster,
                                                uint8_t command_id,
@@ -127,17 +128,62 @@ void sync_indicator_led(zigbee_relay_cluster *cluster) {
 }
 
 void relay_cluster_on(zigbee_relay_cluster *cluster) {
-  relay_on(cluster->relay);
+  relay_cluster_on_impl(cluster, false);
+}
+
+void relay_cluster_on_from_startup(zigbee_relay_cluster *cluster) {
+  relay_cluster_on_impl(cluster, true);
+}
+
+void relay_cluster_on_impl(zigbee_relay_cluster *cluster, bool from_startup) {
+
+  bool relay_detached = false;
+
+  if (!from_startup) {
+    relay_detached = (cluster->detached_mode == ZCL_ONOFF_RELAY_MODE_DETACHED);
+  }
+
+  relay_on(cluster->relay, relay_detached);
   sync_indicator_led(cluster);
 }
 
 void relay_cluster_off(zigbee_relay_cluster *cluster) {
-  relay_off(cluster->relay);
+  relay_cluster_off_impl(cluster, false);
+}
+
+void relay_cluster_off_from_startup(zigbee_relay_cluster *cluster) {
+  relay_cluster_off_impl(cluster, true);
+}
+
+void relay_cluster_off_impl(zigbee_relay_cluster *cluster, bool from_startup) {
+
+  bool relay_detached = false;
+
+  if (!from_startup) {
+    relay_detached = (cluster->detached_mode == ZCL_ONOFF_RELAY_MODE_DETACHED);
+  }
+
+  relay_off(cluster->relay, relay_detached);
   sync_indicator_led(cluster);
 }
 
 void relay_cluster_toggle(zigbee_relay_cluster *cluster) {
-  relay_toggle(cluster->relay);
+  relay_cluster_toggle_impl(cluster, false);
+}
+
+void relay_cluster_toggle_from_startup(zigbee_relay_cluster *cluster) {
+  relay_cluster_toggle_impl(cluster, true);
+}
+
+void relay_cluster_toggle_impl(zigbee_relay_cluster *cluster, bool from_startup) {
+
+  bool relay_detached = false;
+  
+  if (!from_startup) {
+    relay_detached = (cluster->detached_mode == ZCL_ONOFF_RELAY_MODE_DETACHED);
+  }
+
+  relay_toggle(cluster->relay, relay_detached);
   sync_indicator_led(cluster);
 }
 
@@ -213,26 +259,26 @@ void relay_cluster_handle_startup_mode(zigbee_relay_cluster *cluster) {
 
   switch (cluster->startup_mode) {
   case ZCL_START_UP_ONOFF_SET_ONOFF_TO_OFF:
-    relay_cluster_off(cluster);
+    relay_cluster_off_from_startup(cluster);
     break;
 
   case ZCL_START_UP_ONOFF_SET_ONOFF_TO_ON:
-    relay_cluster_on(cluster);
+    relay_cluster_on_from_startup(cluster);
     break;
 
   case ZCL_START_UP_ONOFF_SET_ONOFF_TOGGLE:
     if (prev_on) {
-      relay_cluster_off(cluster);
+      relay_cluster_off_from_startup(cluster);
     } else {
-      relay_cluster_on(cluster);
+      relay_cluster_on_from_startup(cluster);
     }
     break;
 
   case ZCL_START_UP_ONOFF_SET_ONOFF_TO_PREVIOUS:
     if (prev_on) {
-      relay_cluster_on(cluster);
+      relay_cluster_on_from_startup(cluster);
     } else {
-      relay_cluster_off(cluster);
+      relay_cluster_off_from_startup(cluster);
     }
     break;
   }

--- a/src/zigbee/relay_cluster.h
+++ b/src/zigbee/relay_cluster.h
@@ -12,6 +12,7 @@ typedef struct {
   uint8_t endpoint;
   uint8_t startup_mode;
   uint8_t indicator_led_mode;
+  uint8_t detached_mode;
   hal_zigbee_attribute attr_infos[4];
   relay_t *relay;
   led_t *indicator_led;
@@ -23,6 +24,14 @@ void relay_cluster_add_to_endpoint(zigbee_relay_cluster *cluster,
 void relay_cluster_on(zigbee_relay_cluster *cluster);
 void relay_cluster_off(zigbee_relay_cluster *cluster);
 void relay_cluster_toggle(zigbee_relay_cluster *cluster);
+
+void relay_cluster_on_from_startup(zigbee_relay_cluster *cluster);
+void relay_cluster_off_from_startup(zigbee_relay_cluster *cluster);
+void relay_cluster_toggle_from_startup(zigbee_relay_cluster *cluster);
+
+void relay_cluster_on_impl(zigbee_relay_cluster *cluster, bool from_startup);
+void relay_cluster_off_impl(zigbee_relay_cluster *cluster, bool from_startup);
+void relay_cluster_toggle_impl(zigbee_relay_cluster *cluster, bool from_startup);
 
 void relay_cluster_report(zigbee_relay_cluster *cluster);
 


### PR DESCRIPTION
I'm implementing the **'detached relay mode'**
- **Detach physical relay from its virtual state**
(Z2M toggle no longer controls the relay)
- very good idea suggested by @thatmishakov to allow 'toggle_smart_sync' without operating the physical relay
- also allows seeing the bound devices' state in the indicator LEDs of the switch (without operating the physical relay)

## How it works
- '**detached switch mode**' (already implemented):
  - Button does not trigger relay virtual state
  - Button does not trigger relay physical state
  - Button sends press actions to Z2M
  - Button sends commands to bound devices

- '**detached relay mode**' (new)
used with 'switch relay modes': press_start/short_press/long_press
  - **Button triggers relay virtual state**
    - this reflects state of bound devices  
    (add the relay endpoint to the bound group to keep them in sync)
    - this allows toggle_smart to work
    - this triggers the state indicator LEDs
  - **Button does not trigger relay physical state**
  - Button sends press action to Z2M
  - Button sends commands to bound devices
  - Options variant 1: attached (0, false), detached (1, true)
    - used in my commit
    - To actually toggle the physical relay: Select attached, toggle the relay and go back to detached.
    - Power-on-behavior must ignore this option. It should always toggle the physical relay.
  - Options variant 2: attached (0), detached_on (1), detached_off (2)
    - probably better, not sure how to implement
    - Toggle the physical relay by selecting 1 or 2
      This should execute on start-up and option select
    - Power-on-behavior triggers relay virtual state
    - Power-on-behavior does not trigger relay physical state

## Progress

I prepared the source code for the new option, but I'm having trouble with attributes and NV. 
Whatever I add, it performs very strange. 
- Should it be part of the Relay OnOff cluster?
Or should I add a new cluster OnOffConfig? Does it really matter?
- Can I change the order at SETUP_ATTR?
So the optional attributes (indicator mode) are kept last (2&3 becomes 3&4)
- Should we handle the new attribute with lastSeenVersion?
(read from NV n attributes or n+1 attributes depending on version?? I don't think we did this before)
- I think I should switch to the 'options variant 2'