### PR TITLE
Add support for BSEED 2g switch variant (TS0012 / _TZ3000_e98krvvk)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -634,6 +634,32 @@ BSEED_TOUCH_2_TS0012:
   info: Higher power draw (Wrong bi-stable relay implementation)
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/51
   store: https://www.aliexpress.com/item/1005003324697513.html
+BSEED_TOUCH_3_TS0012:
+  human_name: BSEED 2-gang touch switch (no neutral)
+  category: switch
+  power: mains
+  neutral: without
+  device_type: end_device
+  tuya_model_name: TS0012
+  tuya_manufacturer_name: _TZ3000_e98krvvk
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0012
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: e98krvvk;Bseed-2-gang-3;LC3;SB6u;RD3;IC2;SA1u;RC0;IB4;M;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 43569
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/issues/229
+  store: https://www.aliexpress.com/item/1005002570240546.html
 BSEED_TOUCH_TS0001:
   human_name: BSEED 1-gang touch switch 🅰
   category: switch


### PR DESCRIPTION
The ZTU-based device is assigned `firmware_image_type: 43569` and uses the following pinout:

 Pin | Description         | Notes                                  |
-----|---------------------|----------------------------------------|
 C3  | Network Indicator   | Red LEDs for both gangs wired together |
 B6  | Left Switch         | 10k pullup                             |
 D3  | Left Relay          |                                        |
 C2  | Left Indicator LED  |                                        |
 A1  | Right Switch        | 10k pullup                             |
 C0  | Right Relay         |                                        |
 B4  | Right Indicator LED |                                        |

Issue: #229 