### PR TITLE
Add FS-02Z device (in_progress - probably non-standard ZT2S module)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -2026,7 +2026,7 @@ TUYA_8_TS0001:
   tuya_module: ZT2S
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: fdxihpp7;WHD02-FS02Z;BD2u;LB4i;SB5u;RC3;
+  config_str: fdxihpp7;WHD02-FS02Z;BD2u;LB4i;SB5u;RC3i;
   alt_config_str: null
   old_manufacturer_names: null
   old_zb_models: null

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -871,7 +871,7 @@ FS02Z_TS0001:
   status: in_progress
   info: Device probably not supported as it is built on top of non-standard zt2s module. Stops responding after OTA update. Wired flashing also unsuccessful.
   threads: null
-  store: null
+  store: https://www.aliexpress.com/item/1005006908878393.html
 GIRIER_TS0001:
   human_name: Girier JR-ZDS01 🅱
   category: module

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -870,7 +870,7 @@ FS02Z_TS0001:
   build: no
   status: in_progress
   info: Device probably not supported as it is built on top of non-standard zt2s module. Stops responding after OTA update. Wired flashing also unsuccessful.
-  threads: null
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/243
   store: https://www.aliexpress.com/item/1005006908878393.html
 GIRIER_TS0001:
   human_name: Girier JR-ZDS01 🅱

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -867,9 +867,9 @@ FS02Z_TS0001:
   tuya_manufacturer_id: 4417
   tuya_image_type: 54179
   firmware_image_type: 45629
-  build: yes
+  build: no
   status: in_progress
-  info: Testing pinout
+  info: Device probably not supported as it is built on top of non-standard zt2s module. Stops responding after OTA update. Wired flashing also unsuccessful.
   threads: null
   store: null
 GIRIER_TS0001:

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -846,6 +846,32 @@ EMOS_TS0002:
   store:
   - https://www.emosgosmart.eu/en/products/gosmart-switch-module-ip-2102sz-zigbee-2-channel/
   - https://www.amazon.de/dp/B0DDCKHXDL
+FS02Z_TS0001:
+  human_name: FS-02Z 1CH Mini Smart Switch
+  category: module
+  power: mains
+  neutral: required
+  device_type: router
+  tuya_model_name: TS0001
+  tuya_manufacturer_name: _TZ3000_fdxihpp7
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: WHD02
+  override_z2m_device: null
+  tuya_module: ZT2S
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: fdxihpp7;WHD02-FS02Z;BD2u;LB4i;SB5u;RC3;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 45629
+  build: yes
+  status: in_progress
+  info: Testing pinout
+  threads: null
+  store: null
 GIRIER_TS0001:
   human_name: Girier JR-ZDS01 🅱
   category: module

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -846,32 +846,6 @@ EMOS_TS0002:
   store:
   - https://www.emosgosmart.eu/en/products/gosmart-switch-module-ip-2102sz-zigbee-2-channel/
   - https://www.amazon.de/dp/B0DDCKHXDL
-FS02Z_TS0001:
-  human_name: FS-02Z 1CH Mini Smart Switch
-  category: module
-  power: mains
-  neutral: required
-  device_type: router
-  tuya_model_name: TS0001
-  tuya_manufacturer_name: _TZ3000_fdxihpp7
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: WHD02
-  override_z2m_device: null
-  tuya_module: ZT2S
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: fdxihpp7;WHD02-FS02Z;BD2u;LB4i;SB5u;RC3;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  tuya_manufacturer_id: 4417
-  tuya_image_type: 54179
-  firmware_image_type: 45629
-  build: no
-  status: in_progress
-  info: Device probably not supported as it is built on top of non-standard zt2s module. Stops responding after OTA update. Wired flashing also unsuccessful.
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/243
-  store: https://www.aliexpress.com/item/1005006908878393.html
 GIRIER_TS0001:
   human_name: Girier JR-ZDS01 🅱
   category: module
@@ -2038,6 +2012,32 @@ TUYA_6_TS0001:
   info: Supported
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/225
   store: https://www.t-led.cz/p/smart-zigbee-3-0-spinac-zb2-68506
+TUYA_8_TS0001:
+  human_name: FS-02Z 1CH Mini Smart Switch
+  category: module
+  power: mains
+  neutral: required
+  device_type: router
+  tuya_model_name: TS0001
+  tuya_manufacturer_name: _TZ3000_fdxihpp7
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: WHD02
+  override_z2m_device: null
+  tuya_module: ZT2S
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: fdxihpp7;WHD02-FS02Z;BD2u;LB4i;SB5u;RC3;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 45629
+  build: no
+  status: in_progress
+  info: Device probably not supported as it is built on top of non-standard zt2s module. Stops responding after OTA update. Wired flashing also unsuccessful.
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/243
+  store: https://www.aliexpress.com/item/1005006908878393.html
 TUYA_TS0002:
   human_name: Tuya 2-gang
   category: module


### PR DESCRIPTION
## Device Information
- Model: FS-02Z 1CH Mini Smart Switch
- MCU: ?? (ZT2S module - probably non-standard variant — no single label on chip)
- Manufacturer: _TZ3000_fdxihpp7
- Stock Model: WHD02 (Tuya)
- Category: Module (requires neutral)
- Z2M documentation: https://www.zigbee2mqtt.io/devices/WHD02.html#tuya-whd02

## Status
Device entry added with `in_progress` status and `build: no`.

## Issue
Device appears to use a non-standard ZT2S module variant. Both flashing methods were attempted:
- **OTA update**: Device accepts firmware but stops responding after update
- **Wired flashing**: Also unsuccessful

## Configuration
Pinout determined from PCB inspection:
- Button: D2 (pull-up)
- LED: B4 (inverted)
- Switch: B5 (pull-up)
- Relay: C3

Config string: `fdxihpp7;WHD02-FS02Z;BD2u;LB4i;SB5u;RC3;`

## Purpose
Adding to database for documentation purposes and to help others who may encounter this device.


## Images

<img src="https://github.com/user-attachments/assets/7b7f9a4f-ed48-4064-bdad-ad4a4cd88f73" align="top" width="60%"/>
<img src="https://github.com/user-attachments/assets/76fc955b-b33a-4d81-b5cc-cd06c79722f8" align="top" width="60%"/>
<img src="https://github.com/user-attachments/assets/aafccd63-2b51-439f-a198-8e3af43df362" align="top" width="40%"/>

<p></p>

Note the chip, it doesn't have a single label

<img src="https://github.com/user-attachments/assets/e77c37ac-d379-45dd-aba0-6dbadad8440d" align="top" width="40%"/>
<img src="https://github.com/user-attachments/assets/3252063c-4f92-4562-bdd2-f3a2767b5949" align="top" width="40%"/>

Edit: compressed images