### PR TITLE
Support more BSEED 3g variants ( _TZ3000_kfwhmnvc /  _TZ3000_5e5ptb24)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -842,6 +842,32 @@ BSEED_TOUCH_TS0003_2:
   info: Backlight on D4i
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/240
   store: https://www.aliexpress.com/item/1005004187227246.html
+BSEED_TOUCH_2_TS0013:
+  human_name: BSEED 3-gang touch switch
+  category: switch
+  power: mains
+  neutral: without
+  device_type: end_device
+  tuya_model_name: TS0013
+  tuya_manufacturer_name: _TZ3000_kfwhmnvc
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0013
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: kfwhmnvc;TS0013-2-BS;LC3;SB5u;RC0B6;ID2;SB4u;RA1D7;IC2;SD4u;RA0C1;ID3;M;SLP;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  tuya_manufacturer_id: 4417
+  tuya_image_type: 54179
+  firmware_image_type: 43580
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/issues/229
+  store: https://www.aliexpress.com/item/1005002570240546.html
 EKF_TS0012:
   human_name: EKF ssh-2g-zb-nn
   category: module


### PR DESCRIPTION
Both variants are ZTU-based and have the following pinouts

-----
`_TZ3000_kfwhmnvc` variant:

Pin | Description         | Notes                                  |
--------|---------------------|----------------------------------------|
C3      | Network Indicator   | Red LEDs for all gangs wired together  |
B5      | Left Switch         | 10k pullup                             |
C0/B6   | Left Relay          | Bi-stable relay setup                  |
D2      | Left Indicator LED  |                                        |
B4      | Middle Switch       | 10k pullup                             |
A1/D7   | Middle Relay        | Bi-stable relay setup                  |
C2      | Middle Indicator LED|                                        |
D4      | Right Switch        | 10k pullup                             |
A0/C1   | Right Relay         | Bi-stable relay setup                  |
D3      | Right Indicator LED |                                        |

-----

` _TZ3000_5e5ptb24` variant:

 Pin | Description         | Notes                                  |
-----|---------------------|----------------------------------------|
 D2  | Network Indicator   | Red LEDs for all gangs wired together  |
 B6  | Left Switch         | 10k pullup                             |
 D3  | Left Relay          |                                        |
 C3  | Left Indicator LED  |                                        |
 A0  | Middle Switch       | 10k pullup                             |
 D7  | Middle Relay        |                                        |
 C2  | Middle Indicator LED|                                        |
 A1  | Right Switch        | 10k pullup                             |
 C0  | Right Relay         |                                        |
 B5  | Right Indicator LED |                                        |


Fixes https://github.com/romasku/tuya-zigbee-switch/issues/229