### PR TITLE
Add PSMART Device  (based on moes g4)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1986,7 +1986,7 @@ PSMART_SWITCH_TS0001:
   category: switch
   power: mains
   neutral: required
-  device_type: end_device
+  device_type: router
   tuya_model_name: TS0001
   tuya_manufacturer_name: _TZ3000_myaaknbq
   stock_converter_manufacturer: Tuya


### PR DESCRIPTION
**Device Information**
Model: PSMART 1 Gang, Momentary, T441 / T451
MCU: EFR32MG21A020F768IM32
Manufacturer: _TZ3000_myaaknbq
Stock Model: TS0001 (Tuya)
Category: Switch (requires neutral)
Z2M documentation: https://www.zigbee2mqtt.io/devices/T441.html#psmart-t441
Status
Device entry added with mostly_supported status and build: yes.
Tested on moes firmware. 

**Issue**
Missing support for backlight. 

OTA update: Device not visible in Z2M (before applying custom firmware)
Wired flashing: Succesfull
Configuration

**Pinout determined from PCB inspection:**
VCC <- 103 -> common (from button so gnd)
MCU PIN <- 102 -> common

J5 - 4 pin 5v / 3v3?
J5 -5, 6 GND

A6 - button middle
A3 - button left
A0 - right buttton
B0 - relay (transistor)
A4 -relay 2 (transistor)
D1 - relay 3 (transistor)

A5 - blue led
A5 - red led
A0 - invert led blue

C0 - led 6 (?)
C1 - Led 2

config_str: myaaknbq;T441;SA6u;RB0;IA0;M;SLP;
alt_config_str: myaaknbq;T441;SA6u;RA5;IA0i;M;SLP;


![IMG_0061](https://github.com/user-attachments/assets/bbad610a-3d45-47a4-b610-87bf83c6aa99)
![IMG_0062](https://github.com/user-attachments/assets/5e89962f-94d7-47fb-a6c5-7e0d0c56cee5)
![IMG_0064](https://github.com/user-attachments/assets/c61ebf6e-6bc2-4d68-9ed5-8ec2b1c1fddd)
![IMG_0065](https://github.com/user-attachments/assets/a9dc8210-b0dc-4b1b-a5c3-551a2fac74c2)



Tested on one of my switches (so far only one). Works fine, love direct binding with my ikea lamp :) 