### PR TITLE
Remove acknowledgment for pvvx/ZigbeeTLc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,8 +75,6 @@ Discuss, troubleshoot and follow the updates on Discord 🙂
 
 ## 🙏 Acknowledgements
 
-- [pvvx/ZigbeeTLc](https://github.com/pvvx/ZigbeeTLc)  
-  ⤷ fw for Telink temp-humidity sensors (base of this project)
 - [doctor64/tuyaZigbee](https://github.com/doctor64/tuyaZigbee)  
   ⤷ fw for other Tuya Zigbee devices (helpful examples)
 - [medium.com/@omaslyuchenko](https://medium.com/@omaslyuchenko)  


### PR DESCRIPTION
Removed acknowledgment for pvvx/ZigbeeTLc from the readme.

https://github.com/pvvx/ZigbeeTLc/commit/3f11d853ab90cd69e4ceb41dc9ed9fdfbb43a2e5

The Russian author has removed a link to this repo due to its support for Ukraine.