### PR TITLE
Fix: Add missing --sdk flag to slc signature trust command

### DIFF
--- a/src/silabs/tools.mk
+++ b/src/silabs/tools.mk
@@ -33,7 +33,7 @@ all: simplicity_sdk commander slc-cli zap trust verify
 trust:
 	@echo "Trusting Silicon Labs SDK signature..."
 	$(TOOLS_DIR)/slc-cli/slc signature trust --sdk $(TOOLS_DIR)/simplicity_sdk
-	$(TOOLS_DIR)/slc-cli/slc signature trust -extpath $(abspath $(TOOLS_DIR)/spiflash_extension)
+	$(TOOLS_DIR)/slc-cli/slc signature trust --sdk $(TOOLS_DIR)/simplicity_sdk -extpath $(abspath $(TOOLS_DIR)/spiflash_extension)
 
 # Help target
 help:


### PR DESCRIPTION
The second slc signature trust command in tools.mk was missing the --sdk flag, causing the build to fail with 'No SDK' error. and then
> Clear out index files
> Process completed with exit code 1.