### PR TITLE
Align pairing mode trigger with documented behavior (10 presses)

### DIFF
--- a/src/zigbee/switch_cluster.c
+++ b/src/zigbee/switch_cluster.c
@@ -380,7 +380,7 @@ void reset_tasks_handler(void *arg) { hal_system_reset(); }
 
 void switch_cluster_on_button_multi_press(zigbee_switch_cluster *cluster,
                                           uint8_t press_count) {
-  if (press_count > MULTI_PRESS_CNT_TO_RESET) {
+  if (press_count >= MULTI_PRESS_CNT_TO_RESET) {
     hal_factory_reset();
   }
 }


### PR DESCRIPTION
When following the documentation to enter pairing mode by pressing the switch 10 times, I found that it actually requires 11 presses. I believe this may be an unintentional off-by-one error.

The constant `MULTI_PRESS_CNT_TO_RESET` is defined as `10`, and the documentation mentions 10 presses, but the condition uses `>` (greater than) instead of `>=`:

If requiring 11 presses was intentional, please let me know and I can update the documentation instead. Happy to adjust this PR based on the intended behavior!