### PR TITLE
Align leave-network unit test with new press count

### DIFF
--- a/tests/test_network_join.py
+++ b/tests/test_network_join.py
@@ -65,10 +65,14 @@ def test_leaves_on_multipress() -> None:
         device = Device(proc)
         assert device.status()["joined"] == str(HAL_ZIGBEE_NETWORK_JOINED)
 
-        for _ in range(11):
+        # 9 presses should not cause the device to leave the network
+        for _ in range(9):
             device.click_button("A0")
-            device.step_time(60)
 
+        assert device.status()["joined"] == str(HAL_ZIGBEE_NETWORK_JOINED)
+
+        # 10th press should cause the device to leave the network
+        device.click_button("A0")
         assert device.status()["joined"] != str(HAL_ZIGBEE_NETWORK_JOINED)
 
 


### PR DESCRIPTION
PR #272 changed the leave-network press count from 11 to 10, but I didn’t realize there was a unit test covering this. This PR updates the unit test to verify the exact number of presses.