### PR TITLE
🔨 Fix `toggle_smart_sync` in Z2M 2.7.2

### DIFF
--- a/helper_scripts/templates/switch_custom.js.jinja
+++ b/helper_scripts/templates/switch_custom.js.jinja
@@ -31,7 +31,7 @@ const romasku = {
             endpointName,
             lookup: { on_off: 0, off_on: 1, toggle_simple: 2, toggle_smart_sync: 3, toggle_smart_opposite: 4 },
             cluster: "genOnOffSwitchCfg",
-            attribute: "switchActions", // Enum8
+            attribute: {ID: 0x0010, type: 0x30, required: true, write: true, min: 0, max: 4}, // Enum8
             description: `Select how switch should work:
             - on_off: When switch physically moved to position 1 it always generates ON command, and when moved to position 2 it generates OFF command
             - off_on: Same as on_off, but positions are swapped


### PR DESCRIPTION
Some checks/restrictions were introduced in Z2M 2.7.2 that block off-spec commands.
They prevent us from setting values 3 and 4 for switchAction (max 2).

This PR overwrites maximum to 4.

- Fixes #291 

---

**For users, here is the new converter that fixes this issue: [switch_custom.js](https://github.com/user-attachments/files/24602986/switch_custom.js)**