### PR TITLE
Fix incorrect pinout for BSEED-2G (l9brjwau)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -2382,7 +2382,7 @@ SWITCH_BSEED_TOUCH_BACKLIGHT_TS0002:
   firmware_image_type: 43581
   build: yes
   status: mostly_supported
-  info: Backlight on D4i; turn on network LED in Z2M settings to enable backlight 
+  info: Backlight on D4i, netled on C4. Left indicator hard-wired?
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/246
   store: https://www.aliexpress.com/item/1005003843553626.html
 SWITCH_BSEED_TOUCH_BACKLIGHT_TS0003:


### PR DESCRIPTION
This change updates the config for l9brjwau (2G BSEED w/ neutral) as follows:

- Set the network led to D4i; This pin controls the led backlights so using it as the network led and turning network led on in the Z2M config ensures the backlight is on.
- Fix a typo with the relay/led definitions for the left gang which conflicted with the switch definition for the right gang.

NOTE: AFAICT, while D7 controls the right led indicator, there is no equivalent pin to control the left led indicator on this particular device (tried using all remaining pins as the network led but was unable to locate the pin that would  turn on the left led). The indicator pin for the left led has been tied to an unused pin instead which is probably fine since the relay is wired to the led anyway.