### PR TITLE
📝 Fix ZBMINIL2 wiring

### DIFF
--- a/docs/flashing/zbminil2.md
+++ b/docs/flashing/zbminil2.md
@@ -52,8 +52,8 @@ Finally, attach the wires to your J-Link programmer.
 Connect:
 - L-in to ground
 - 3.3v device pin to 3.3v source
-- TCK to SWCLK
-- TMS to SWIO 
+- TCK (device) to RTCK (pin 11 J-Link)
+- TMS (device) to TDO  (pin 13 J-Link)
 
 
 ### Step 3: Flash the Firmware


### PR DESCRIPTION
Someone was really struggling with the wiring..

They were trying with pins TCK (9) and TMS (7), 
but I see in the picture from [silabs.md](https://github.com/romasku/tuya-zigbee-switch/blob/main/docs/flashing/silabs.md) that you used RTCK (11) and TDO (13).

Can you double check if this is correct? Or am I reading the diagram wrong?

<img width="25%"  alt="pinout" src="https://github.com/user-attachments/assets/36061731-e234-4acc-a5f0-b557ecc94db1" />

<img width="80%" alt="image" src="https://github.com/user-attachments/assets/1220a2d2-3096-4b4f-aae9-a53572cad075" />
