### PR TITLE
✨ Respond to MoveToLevelWithOnOff

### DIFF
--- a/docs/changelog_fw.md
+++ b/docs/changelog_fw.md
@@ -8,8 +8,13 @@ Please describe what you are working on:
 
 ### Features
 
-- **Cover cluster** (window covering) for controlling the motor of curtains, blinds, and shutters. Supports open, close, and stop commands with motor safety delays.
-- **Cover switch cluster** for handling user input from window covering switches. Supports toggle/momentary switches, stop-on-repeat, stop button, local control, and remote device binding.
+- **Cover cluster** (window covering) for controlling the motor of curtains, blinds, and shutters.  
+  Supports open, close, and stop commands with motor safety delays.
+- **Cover switch cluster** for handling user input from window covering switches.  
+  Supports toggle/momentary switches, stop-on-repeat, stop button, local control, and remote device binding.
+- Relays now respond to *MoveToLevelWithOnOff*
+  - Level = 0 -> Turn off relay
+  - Level > 0 -> Turn on  relay
 
 ### Changes
 

--- a/make_scripts/make_debug_single.sh
+++ b/make_scripts/make_debug_single.sh
@@ -17,7 +17,7 @@
 set -e                                           # Exit on error.
 cd "$(dirname "$(dirname "$(realpath "$0")")")"  # Go to project root.
 
-DEVICE=AVATTO_TS0004  # Change this to your device
+DEVICE=BOARD__ZIGBEE_ZTU_2  # Change this to your device
 
 # Check if device exists in database
 if ! yq -e ".${DEVICE}" device_db.yaml >/dev/null 2>&1; then

--- a/src/telink/hal/zigbee_zcl.c
+++ b/src/telink/hal/zigbee_zcl.c
@@ -80,7 +80,16 @@ static status_t cmd_callback_window_covering(zclIncomingAddrInfo_t *pAddrInfo, u
                         cmdPayload);
 }
 
+static status_t cmd_callback_level_control(zclIncomingAddrInfo_t *pAddrInfo, u8 cmdId,
+                                           void *cmdPayload) {
+    return cmd_callback(pAddrInfo->dstEp, ZCL_CLUSTER_GEN_LEVEL_CONTROL, cmdId,
+                        cmdPayload);
+}
+
 static cluster_forAppCb_t get_cmd_callback_by_cluster_id(u16 cluster_id) {
+    if (cluster_id == ZCL_CLUSTER_GEN_LEVEL_CONTROL) { // Level Control cluster
+        return cmd_callback_level_control;
+    }
     if (cluster_id == ZCL_CLUSTER_GEN_ON_OFF) { // On/Off cluster
         return cmd_callback_on_off;
     }


### PR DESCRIPTION
Device now responds to *MoveToLevelWithOnOff*
  - Level = 0 -> Turn off relay
  - Level > 0 -> Turn on  relay

Tested on Telink (router) board and stub device.
I don't think anything extra is needed for Silabs.

@LorandBiro would this conflict with covers in any way? 😬 
They use entirely different commands, right? 
Does the relay stop reacting to normal on/off/toggle commands if you put it in cover mode?