### PR TITLE
Update device_db.yaml - add Moes MS-104CZ end device option (pfc7i3kt)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1568,7 +1568,7 @@ MODULE_MOES_TS0003:
   power: mains
   neutral: required
   output: relay
-  device_type: router
+  device_type: end_device # enable end device option for poor signal scenarios
   stock_model_name: TS0003
   stock_manufacturer_name: _TZ3000_pfc7i3kt
   stock_converter_manufacturer: Tuya


### PR DESCRIPTION
Add end_device build option for Moes MS-104CZ (pfc7i3kt) to improve network reliability where it has low signal strength