### PR TITLE
Add support for Mini Smart Switch iHSW02

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -202,33 +202,6 @@ BOARD__ZIGBEE_ZTU_2:
   info: Supported
   threads: null
   store: https://www.aliexpress.com/item/1005007599675462.html
-MODULE_MSMARTSW_TS0001:
-  human_name: Mini Smart Sw iHSW02
-  category: module
-  power: mains
-  neutral: required
-  output: relay
-  device_type: end_device
-  stock_model_name: TS0001
-  stock_manufacturer_name: _TZ3000_rmjr4ufz
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: WHD02
-  override_z2m_device: null
-  tuya_module: ZTU
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: rmjr4ufz;iHSW02-MiniSmartSw;BC3u;SB5u;LC2i;RD2;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 54179
-  firmware_image_type: 43641
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: null
-  store: null
 MODULE_AUBESS_TS0001:
   human_name: Aubess WHD02
   category: module
@@ -1561,6 +1534,33 @@ MODULE_IHSENO_A_TS0001:
   status: fully_supported
   info: Supported
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/340
+  store: null
+MODULE_IHSENO_B_TS0001:
+  human_name: iHseno 1-gang 🅱
+  category: module
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0001
+  stock_manufacturer_name: _TZ3000_rmjr4ufz
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: WHD02
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: rmjr4ufz;iHSW02-MiniSmartSw;BC3u;LC2i;SB5u;RD2;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 43641
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/386
   store: null
 MODULE_LVGESS_PM_TSOOO1:
   human_name: LVGESS 1-gang PM
@@ -3027,7 +3027,7 @@ REMOTE_TUYA_TS0044:
   info: Huge battery drain! LEDs on C1, C2, C0, D0
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/171
   store: null
-REMOTE_TUYA_TLSR82xx_2GANG:
+REMOTE_TUYA_TLSR82XX_2GANG:
   human_name: Tuya 2-button remote
   category: remote
   power: AAA

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -202,6 +202,33 @@ BOARD__ZIGBEE_ZTU_2:
   info: Supported
   threads: null
   store: https://www.aliexpress.com/item/1005007599675462.html
+MODULE_MSMARTSW_TS0001:
+  human_name: Mini Smart Sw iHSW02
+  category: module
+  power: mains
+  neutral: required
+  output: relay
+  device_type: end_device
+  stock_model_name: TS0001
+  stock_manufacturer_name: _TZ3000_rmjr4ufz
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: WHD02
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: rmjr4ufz;iHSW02-MiniSmartSw;BC3u;SB5u;LC2i;RD2;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 43641
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: null
+  store: null
 MODULE_AUBESS_TS0001:
   human_name: Aubess WHD02
   category: module


### PR DESCRIPTION
This is no name brand smart switch labeled "Mini Smart Switch", model "iHSW02". Outer case is 1to1 compared to Aubess WHD02. The board inside is different layout with the same size, cutouts for the case and connector. It's using ZTU module.
Tested on my device, everything is working fine.