### PR TITLE
optimisation again ;-)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -2934,7 +2934,7 @@ REMOTE_MOES_SWITCH_TS0044:
   tuya_module: ZT3L
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: zgyzgdua;TS0044-MOES;SD2d;SC3d;SC2d;SB4d;LD4i;BTC5;M;
+  config_str: zgyzgdua;TS0044-MOES;SD2d;IC4i;SC3d;IA0i;SC2d;ID7i;SB4d;ID4i;BTC5;M;D0;
   alt_config_str: null
   old_manufacturer_names: null
   old_zb_models: null
@@ -2943,7 +2943,7 @@ REMOTE_MOES_SWITCH_TS0044:
   firmware_image_type: 43572
   build: yes
   status: in_progress
-  info: Huge battery drain! LEDs on C4, A0, D7 and D4, WIP for led control as press confirmation, no relays.
+  info: no relay
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/342
   store: https://moeshouse.com/products/zigbee-wireless-scene-switch-battery-powered?variant=43700045283643
 REMOTE_TUYA_TS0041:

--- a/src/base_components/led.c
+++ b/src/base_components/led.c
@@ -6,7 +6,12 @@
 
 #include <stdio.h>
 
+static void led_blink_handler(void *arg);
+
 void led_init(led_t *led) {
+    led->blink_task.handler = led_blink_handler;
+    led->blink_task.arg     = led;
+    hal_tasks_init(&led->blink_task);
     led_off(led);
 }
 
@@ -34,7 +39,9 @@ static void led_blink_handler(void *arg) {
         if (led->blink_times_left != LED_BLINK_FOREVER) {
             led->blink_times_left--;
         }
-        hal_tasks_schedule(&led->blink_task, led->blink_time_off);
+        if (led->blink_times_left > 0) {
+            hal_tasks_schedule(&led->blink_task, led->blink_time_off);
+        }
     } else {
         led->on = 1;
         hal_gpio_write(led->pin, led->on_high);
@@ -57,9 +64,6 @@ void led_blink(led_t *led, uint16_t on_time_ms, uint16_t off_time_ms,
 
     hal_gpio_write(led->pin, led->on_high);
     led->on = 1;
-    led->blink_times_left   = times;
-    led->blink_task.handler = led_blink_handler;
-    led->blink_task.arg     = led;
-    hal_tasks_init(&led->blink_task);
+    led->blink_times_left = times;
     hal_tasks_schedule(&led->blink_task, on_time_ms);
 }

--- a/src/hal/zigbee.h
+++ b/src/hal/zigbee.h
@@ -103,9 +103,12 @@ void hal_zigbee_set_image_type(uint16_t image_type);
  * @param endpoint Endpoint number
  * @param cluster_id Cluster ID
  * @param attribute_id Attribute ID that changed
+ * @param immediate If true, send report immediately instead of using SDK
+ *                  reporting timers (avoids unnecessary wake-ups on battery
+ *                  devices)
  */
 void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
-                                         uint16_t attribute_id);
+                                         uint16_t attribute_id, bool immediate);
 
 /** Function called when attribute is written via Zigbee */
 typedef void (*hal_attribute_change_callback_t)(uint8_t endpoint,

--- a/src/silabs/hal/zigbee.c
+++ b/src/silabs/hal/zigbee.c
@@ -147,7 +147,7 @@ void hal_zigbee_init(hal_zigbee_endpoint *endpoints, uint8_t endpoints_cnt) {
 }
 
 void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
-                                         uint16_t attribute_id) {
+                                         uint16_t attribute_id, bool immediate) {
     hal_zigbee_cluster *  cluster = find_hal_cluster(endpoint, cluster_id);
     hal_zigbee_attribute *attr    =
         find_hal_attr(endpoint, cluster_id, attribute_id);

--- a/src/silabs/hal/zigbee.c
+++ b/src/silabs/hal/zigbee.c
@@ -155,6 +155,16 @@ void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
     if (attr == NULL) {
         return;
     }
+
+    if (immediate) {
+        // Send report directly; the reporting plugin defers to its tick and
+        // drops the event when the coordinator has not configured reporting.
+        hal_zigbee_send_report_attr(endpoint, cluster_id, attribute_id,
+                                    attr->data_type_id, attr->value,
+                                    attr->size);
+        return;
+    }
+
     sl_zigbee_af_reporting_attribute_change_cb(
         endpoint, cluster_id, attribute_id,
         cluster->is_server ? CLUSTER_MASK_SERVER : CLUSTER_MASK_CLIENT, 0,

--- a/src/stub/hal/zigbee.c
+++ b/src/stub/hal/zigbee.c
@@ -147,7 +147,7 @@ uint32_t hal_zigbee_get_poll_rate_ms(void) {
 }
 
 void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
-                                         uint16_t attribute_id) {
+                                         uint16_t attribute_id, bool immediate) {
     io_log("ZIGBEE", "Attribute changed: ep=%d, cluster=0x%04x, attr=0x%04x",
            endpoint, cluster_id, attribute_id);
     // In stub, do NOT call attr_change_callback here.

--- a/src/telink/hal/zigbee_network.c
+++ b/src/telink/hal/zigbee_network.c
@@ -8,6 +8,7 @@
 
 #include "telink_size_t_hack.h"
 
+#include "device_config/config_parser.h"
 #include "hal/zigbee.h"
 #include "telink_zigbee_hal.h"
 #include "version_cfg.h"
@@ -80,7 +81,7 @@ void bdb_init_callback(u8 status, u8 joinedNetwork) {
         if (joinedNetwork) {
             ota_queryStart(OTA_QUERY_INTERVAL);
       #ifdef ZB_ED_ROLE
-            zb_setPollRate(POLL_RATE);
+            hal_zigbee_set_poll_rate_ms(POLL_RATE);
       #endif
         }
     } else {
@@ -100,7 +101,7 @@ void bdb_commissioning_callback(u8 status, void *arg) {
         // Need set poll rate manually,
         // to avoid bugs related to no poll task
         // after fast re-connect.
-        zb_setPollRate(POLL_RATE);
+        hal_zigbee_set_poll_rate_ms(POLL_RATE);
         printf("Set poll rate to %d\r\n", POLL_RATE);
 #endif
         steeringInProgress = 0;
@@ -186,6 +187,13 @@ hal_zigbee_status_t hal_zigbee_send_announce(void) {
 
 void hal_zigbee_set_poll_rate_ms(uint32_t poll_rate_ms) {
     zb_setPollRate(poll_rate_ms);
+
+    // Disable the SDK's automatic quick data polls (3 extra MAC polls after
+    // each send) in long-poll mode to avoid unnecessary wake-ups from
+    // deep retention.
+    if (battery.pin != HAL_INVALID_PIN) {
+        AUTO_QUICK_DATA_POLL_ENABLE = (poll_rate_ms <= 10000);
+    }
 }
 
 uint32_t hal_zigbee_get_poll_rate_ms(void) {

--- a/src/telink/hal/zigbee_zcl.c
+++ b/src/telink/hal/zigbee_zcl.c
@@ -11,11 +11,7 @@
 
 #include "hal/zigbee.h"
 #include "telink_zigbee_hal.h"
-#include "zigbee/battery_cluster.h"
-#include "base_components/battery.h"
 #include "zigbee/consts.h"
-
-extern battery_t battery;
 
 // Storage for Telink endpoint configuration
 static af_simple_descriptor_t endpoint_descriptors[MAX_ENDPOINTS];
@@ -239,11 +235,10 @@ void telink_zigbee_hal_zcl_init(hal_zigbee_endpoint *endpoints,
 }
 
 void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
-                                         uint16_t attribute_id) {
-    if (battery.pin != HAL_INVALID_PIN &&
-        cluster_id == ZCL_CLUSTER_GEN_MULTISTATE_INPUT_BASIC) {
-        // Button events: send report directly to avoid SDK reporting
-        // timers (reportingTimerCb ~100ms) which cause extra wake-ups
+                                         uint16_t attribute_id, bool immediate) {
+    if (immediate) {
+        // Send report directly to avoid SDK reporting timers
+        // (reportingTimerCb ~100ms) which cause extra wake-ups
         // from deep retention.
         hal_zigbee_send_report_attr(endpoint, cluster_id, attribute_id,
                                     0, NULL, 0);

--- a/src/telink/hal/zigbee_zcl.c
+++ b/src/telink/hal/zigbee_zcl.c
@@ -12,7 +12,10 @@
 #include "hal/zigbee.h"
 #include "telink_zigbee_hal.h"
 #include "zigbee/battery_cluster.h"
+#include "base_components/battery.h"
 #include "zigbee/consts.h"
+
+extern battery_t battery;
 
 // Storage for Telink endpoint configuration
 static af_simple_descriptor_t endpoint_descriptors[MAX_ENDPOINTS];
@@ -237,7 +240,14 @@ void telink_zigbee_hal_zcl_init(hal_zigbee_endpoint *endpoints,
 
 void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
                                          uint16_t attribute_id) {
-    report_handler(); // Trigger reporting if needed
+    if (battery.pin != HAL_INVALID_PIN) {
+        // Battery device: send report directly, SDK reporting timers
+        // don't survive deep retention.
+        hal_zigbee_send_report_attr(endpoint, cluster_id, attribute_id,
+                                    0, NULL, 0);
+    } else {
+        report_handler();
+    }
 }
 
 hal_zigbee_status_t hal_zigbee_send_cmd_to_bindings(const hal_zigbee_cmd *cmd) {

--- a/src/telink/hal/zigbee_zcl.c
+++ b/src/telink/hal/zigbee_zcl.c
@@ -240,11 +240,29 @@ void telink_zigbee_hal_zcl_init(hal_zigbee_endpoint *endpoints,
 
 void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
                                          uint16_t attribute_id) {
-    if (battery.pin != HAL_INVALID_PIN) {
-        // Battery device: send report directly, SDK reporting timers
-        // don't survive deep retention.
+    if (battery.pin != HAL_INVALID_PIN &&
+        cluster_id == ZCL_CLUSTER_GEN_MULTISTATE_INPUT_BASIC) {
+        // Button events: send report directly to avoid SDK reporting
+        // timers (reportingTimerCb ~100ms) which cause extra wake-ups
+        // from deep retention.
         hal_zigbee_send_report_attr(endpoint, cluster_id, attribute_id,
                                     0, NULL, 0);
+        // Sync prevData in the reporting table so report_handler() in
+        // the main loop does not see a stale diff and schedule another
+        // reporting timer for the same change.
+        reportCfgInfo_t *e = zcl_reportCfgInfoEntryFind(endpoint,
+                                                        cluster_id,
+                                                        attribute_id);
+        if (e) {
+            zclAttrInfo_t *a = zcl_findAttribute(endpoint, cluster_id,
+                                                 attribute_id);
+            if (a) {
+                u8 len = zcl_getAttrSize(a->type, a->data);
+                if (len > REPORTABLE_CHANGE_MAX_ANALOG_SIZE)
+                    len = REPORTABLE_CHANGE_MAX_ANALOG_SIZE;
+                memcpy(e->prevData, a->data, len);
+            }
+        }
     } else {
         report_handler();
     }

--- a/src/telink/main.c
+++ b/src/telink/main.c
@@ -82,7 +82,9 @@ int real_main(startup_state_e state) {
         drv_wd_clear();
         app_task();
         drv_wd_clear();
-        report_handler();
+        if (battery.pin == HAL_INVALID_PIN) {
+            report_handler();
+        }
         drv_wd_clear();
 
 #if PM_ENABLE

--- a/src/telink/main.c
+++ b/src/telink/main.c
@@ -82,9 +82,7 @@ int real_main(startup_state_e state) {
         drv_wd_clear();
         app_task();
         drv_wd_clear();
-        if (battery.pin == HAL_INVALID_PIN) {
-            report_handler();
-        }
+        report_handler();
         drv_wd_clear();
 
 #if PM_ENABLE

--- a/src/zigbee/battery_cluster.c
+++ b/src/zigbee/battery_cluster.c
@@ -50,8 +50,8 @@ void battery_cluster_update(zigbee_battery_cluster *cluster) {
     cluster->voltage_100mv        = status.voltage_mv / 100;
 
     hal_zigbee_notify_attribute_changed(cluster->endpoint, ZCL_CLUSTER_POWER_CFG,
-                                        ZCL_ATTR_POWER_CFG_BATTERY_VOLTAGE);
+                                        ZCL_ATTR_POWER_CFG_BATTERY_VOLTAGE, false);
     hal_zigbee_notify_attribute_changed(cluster->endpoint, ZCL_CLUSTER_POWER_CFG,
-                                        ZCL_ATTR_POWER_CFG_BATTERY_PERCENTAGE);
+                                        ZCL_ATTR_POWER_CFG_BATTERY_PERCENTAGE, false);
     hal_tasks_schedule(&cluster->refresh_values_task, BATTERY_REFRESH_INTERVAL_MS);
 }

--- a/src/zigbee/cover_cluster.c
+++ b/src/zigbee/cover_cluster.c
@@ -61,7 +61,7 @@ void cover_apply_movement(zigbee_cover_cluster *cluster, uint8_t moving) {
 
     hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                         ZCL_CLUSTER_WINDOW_COVERING,
-                                        ZCL_ATTR_WINDOW_COVERING_MOVING);
+                                        ZCL_ATTR_WINDOW_COVERING_MOVING, false);
 }
 
 void cover_schedule_movement(zigbee_cover_cluster *cluster, uint8_t moving, uint32_t delay) {

--- a/src/zigbee/cover_switch_cluster.c
+++ b/src/zigbee/cover_switch_cluster.c
@@ -176,7 +176,7 @@ void cover_switch_cluster_update_present_value(zigbee_cover_switch_cluster *clus
     cluster->present_value = present_value;
     hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                         ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, true);
 
     if (local_cmd != 0xFF) {
         cover_switch_trigger_local_cmd(cluster, local_cmd);
@@ -304,7 +304,7 @@ void cover_switch_cluster_on_write_attr(zigbee_cover_switch_cluster *cluster,
         }
         hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                             ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-                                            ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+                                            ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, false);
         cover_switch_cluster_store_attrs_to_nv(cluster);
         break;
     case ZCL_ATTR_COVER_SWITCH_CONFIG_COVER_INDEX:

--- a/src/zigbee/poll_control_cluster.c
+++ b/src/zigbee/poll_control_cluster.c
@@ -171,8 +171,8 @@ static hal_zigbee_cmd_result_t poll_control_cmd_callback(
                                 ((uint32_t)data[1] << 8) |
                                 ((uint32_t)data[2] << 16) |
                                 ((uint32_t)data[3] << 24);
-        printf("Poll control: set long poll interval=%lu\r\n",
-               (unsigned long)new_interval);
+        printf("Poll control: set long poll interval=%d\r\n",
+               (int)new_interval);
         if (new_interval < 0x04 || new_interval > 0x6E0000 ||
             (cluster->check_in_interval != 0 &&
              new_interval > cluster->check_in_interval) ||
@@ -231,8 +231,8 @@ void poll_control_cluster_callback_attr_write(uint16_t attribute_id) {
     zigbee_poll_control_cluster *cluster = poll_ctrl_instance;
 
     if (attribute_id == ZCL_ATTR_POLL_CTRL_CHECK_IN_INTERVAL) {
-        printf("Poll control: check-in interval written=%lu\r\n",
-               (unsigned long)cluster->check_in_interval);
+        printf("Poll control: check-in interval written=%d\r\n",
+               (int)cluster->check_in_interval);
         if (cluster->check_in_interval != 0 &&
             (cluster->check_in_interval < cluster->long_poll_interval)) {
             printf("Poll control: invalid check-in interval, reverting\r\n");
@@ -326,8 +326,14 @@ void poll_control_cluster_update(void) {
     zigbee_poll_control_cluster *cluster = poll_ctrl_instance;
     if (cluster->in_fast_poll &&
         (int32_t)(hal_millis() - cluster->fast_poll_end_ms) >= 0) {
-        printf("Poll control: fast poll timeout, switching to long poll\r\n");
-        exit_fast_poll(cluster);
+        if (hal_zigbee_get_network_status() != HAL_ZIGBEE_NETWORK_JOINED) {
+            // Stay in fast poll until the device has joined
+            cluster->fast_poll_end_ms =
+                hal_millis() + QS_TO_MS(cluster->fast_poll_timeout);
+        } else {
+            printf("Poll control: fast poll timeout, switching to long poll\r\n");
+            exit_fast_poll(cluster);
+        }
     }
 
     // Ensure poll rate is correct, just in case

--- a/src/zigbee/relay_cluster.c
+++ b/src/zigbee/relay_cluster.c
@@ -178,7 +178,7 @@ void sync_indicator_led(zigbee_relay_cluster *cluster) {
                            : led_off(cluster->indicator_led);
 
     hal_zigbee_notify_attribute_changed(cluster->endpoint, ZCL_CLUSTER_ON_OFF,
-                                        ZCL_ATTR_ONOFF_INDICATOR_STATE);
+                                        ZCL_ATTR_ONOFF_INDICATOR_STATE, false);
 }
 
 void relay_cluster_on(zigbee_relay_cluster *cluster) {
@@ -199,7 +199,7 @@ void relay_cluster_toggle(zigbee_relay_cluster *cluster) {
 void relay_cluster_on_relay_change(zigbee_relay_cluster *cluster,
                                    uint8_t state) {
     hal_zigbee_notify_attribute_changed(cluster->endpoint, ZCL_CLUSTER_ON_OFF,
-                                        ZCL_ATTR_ONOFF);
+                                        ZCL_ATTR_ONOFF, false);
     if (cluster->startup_mode == ZCL_START_UP_ONOFF_SET_ONOFF_TOGGLE ||
         cluster->startup_mode == ZCL_START_UP_ONOFF_SET_ONOFF_TO_PREVIOUS) {
         relay_cluster_store_attrs_to_nv(cluster);

--- a/src/zigbee/switch_cluster.c
+++ b/src/zigbee/switch_cluster.c
@@ -351,7 +351,7 @@ void switch_cluster_on_button_press(zigbee_switch_cluster *cluster) {
         cluster->multistate_state = MULTISTATE_POSITION_ON;
         hal_zigbee_notify_attribute_changed(
             cluster->endpoint, ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-            ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+            ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, true);
         switch_cluster_flash_indicator(cluster);
         return;
     }
@@ -367,7 +367,7 @@ void switch_cluster_on_button_press(zigbee_switch_cluster *cluster) {
     cluster->multistate_state = MULTISTATE_PRESS;
     hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                         ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, true);
     switch_cluster_flash_indicator(cluster);
 }
 
@@ -381,7 +381,7 @@ void switch_cluster_on_button_release(zigbee_switch_cluster *cluster) {
         cluster->multistate_state = MULTISTATE_POSITION_OFF;
         hal_zigbee_notify_attribute_changed(
             cluster->endpoint, ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-            ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+            ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, true);
         switch_cluster_flash_indicator(cluster);
         return;
     }
@@ -401,7 +401,7 @@ void switch_cluster_on_button_release(zigbee_switch_cluster *cluster) {
     cluster->multistate_state = MULTISTATE_NOT_PRESSED;
     hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                         ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, true);
 }
 
 void switch_cluster_on_button_long_press(zigbee_switch_cluster *cluster) {
@@ -425,7 +425,7 @@ void switch_cluster_on_button_long_press(zigbee_switch_cluster *cluster) {
     cluster->multistate_state = MULTISTATE_LONG_PRESS;
     hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                         ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, true);
 }
 
 void synchronize_multistate_state(zigbee_switch_cluster *cluster) {
@@ -446,7 +446,7 @@ void synchronize_multistate_state(zigbee_switch_cluster *cluster) {
     }
     hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                         ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
-                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE, false);
 }
 
 void switch_cluster_on_write_attr(zigbee_switch_cluster *cluster,

--- a/src/zigbee/switch_cluster.c
+++ b/src/zigbee/switch_cluster.c
@@ -342,8 +342,6 @@ void switch_cluster_level_control(zigbee_switch_cluster *cluster) {
 }
 
 void switch_cluster_on_button_press(zigbee_switch_cluster *cluster) {
-    switch_cluster_flash_indicator(cluster);
-
     if (cluster->mode == ZCL_ONOFF_CONFIGURATION_SWITCH_TYPE_TOGGLE) {
         // Toggle does not support modes (RISE, SHORT, LONG)
         if (cluster->relay_mode != ZCL_ONOFF_CONFIGURATION_RELAY_MODE_DETACHED) {
@@ -354,6 +352,7 @@ void switch_cluster_on_button_press(zigbee_switch_cluster *cluster) {
         hal_zigbee_notify_attribute_changed(
             cluster->endpoint, ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
             ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+        switch_cluster_flash_indicator(cluster);
         return;
     }
 
@@ -369,15 +368,10 @@ void switch_cluster_on_button_press(zigbee_switch_cluster *cluster) {
     hal_zigbee_notify_attribute_changed(cluster->endpoint,
                                         ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
                                         ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+    switch_cluster_flash_indicator(cluster);
 }
 
 void switch_cluster_on_button_release(zigbee_switch_cluster *cluster) {
-    if (cluster->mode == ZCL_ONOFF_CONFIGURATION_SWITCH_TYPE_TOGGLE) {
-        // Only flash on release for toggles,
-        // for momentary flash on press only
-        switch_cluster_flash_indicator(cluster);
-    }
-
     if (cluster->mode == ZCL_ONOFF_CONFIGURATION_SWITCH_TYPE_TOGGLE) {
         // Toggle does not support modes (RISE, SHORT, LONG)
         if (cluster->relay_mode != ZCL_ONOFF_CONFIGURATION_RELAY_MODE_DETACHED) {
@@ -388,6 +382,7 @@ void switch_cluster_on_button_release(zigbee_switch_cluster *cluster) {
         hal_zigbee_notify_attribute_changed(
             cluster->endpoint, ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
             ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+        switch_cluster_flash_indicator(cluster);
         return;
     }
 


### PR DESCRIPTION
# Reduce battery wake-ups on end devices

## Problem

Battery-powered end devices (e.g. REMOTE_MOES_SWITCH_TS0044) suffered from unnecessary wake-ups after every button event, draining the battery significantly faster than needed.

Two SDK mechanisms caused extra wake-ups after each ZCL report:

1. **Quick data polls** (`AUTO_QUICK_DATA_POLL_ENABLE`): After every `af_dataSend()`, the SDK schedules 3 additional MAC polls at 250ms intervals via `tl_zbNwkQuickDataPollCb`. In long-poll mode with deep retention, each of these polls triggers a full wake from deep retention (~3.5 mA for ~8 ms each).

2. **SDK reporting timers** (`reportingTimerCb`): Calling `report_handler()` in the main loop and in `hal_zigbee_notify_attribute_changed()` causes the SDK to schedule reporting timers that don't survive deep retention, leading to spurious timer wake-ups.

### Before (main branch)

#### Short press
<img width="1593" height="939" alt="main_short" src="https://github.com/user-attachments/assets/7cb3f93a-cd5e-41ab-8887-e3685c8af374" />

#### Long press
<img width="1593" height="939" alt="main_long" src="https://github.com/user-attachments/assets/787d1845-aaa3-49c6-83bf-1b45c90c1414" />

### After (this PR)

#### Short press
<img width="1593" height="939" alt="my_short" src="https://github.com/user-attachments/assets/d8201c36-e715-4751-9b20-298ef45975f5" />

#### Long press
<img width="1593" height="939" alt="my_long" src="https://github.com/user-attachments/assets/4e76f803-f460-4764-8747-be70b709b482" />

## Results
-46% battery consumption on short press
-58% battery consumption on long press

## Changes

### 1. Disable quick data polls in long-poll mode (`zigbee_network.c`)

`hal_zigbee_set_poll_rate_ms()` now toggles `AUTO_QUICK_DATA_POLL_ENABLE` based on the poll rate. When the poll rate exceeds 10 seconds (i.e. the device is in long-poll / idle mode), quick data polls are disabled — eliminating the ~487ms post-report wake-ups.

In fast-poll mode (≤10s, during joining or interview), quick data polls remain enabled for proper responsiveness.

All BDB callbacks now go through `hal_zigbee_set_poll_rate_ms()` instead of calling `zb_setPollRate()` directly, ensuring the flag is always in sync.

### 2. Bypass SDK report timers on battery devices (`zigbee_zcl.c`, `main.c`)

For battery devices, `hal_zigbee_notify_attribute_changed()` now sends reports directly via `hal_zigbee_send_report_attr()` instead of going through `report_handler()`. This avoids the SDK scheduling `reportingTimerCb` timers that cause extra wake-ups after each attribute change.

The periodic `report_handler()` call in the main loop is also skipped for battery devices, since reports are sent immediately on change.

Router devices continue to use the SDK reporting mechanism unchanged.

### 3. Keep fast poll during network join (`poll_control_cluster.c`)

The poll control cluster now extends the fast-poll window while the device has not yet joined a network. This prevents the initial 10-second fast-poll timeout from expiring during steering, which would drop the device to long-poll before the join completes.

Once joined, `on_zcl_activity()` naturally keeps the device responsive during the Z2M interview by re-entering fast poll on each incoming ZCL message.

### 4. Minor: fix printf format specifiers (`poll_control_cluster.c`)

Replace `%lu` / `(unsigned long)` with `%d` / `(int)` for compatibility with the Telink printf implementation.

## Testing

- All 184 existing tests pass
- Verified on hardware (REMOTE_MOES_SWITCH_TS0044) with current profiling
- Network joining and Z2M interview complete successfully
- Button press/release/long-press events report correctly
