### PR TITLE
Fix config for REMOTE_IHSENO_TS0044

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -2854,8 +2854,10 @@ REMOTE_IHSENO_TS0044:
   firmware_image_type: 43563
   build: yes
   status: in_progress
-  info: Battery Pin is not connected, so will alway report 100%
-  threads: https://github.com/romasku/tuya-zigbee-switch/issues/171
+  info: Battery Pin is not connected, so will always report 100%
+  threads: 
+   - https://github.com/romasku/tuya-zigbee-switch/issues/171
+   - https://github.com/romasku/tuya-zigbee-switch/pull/395
   store:
   - https://www.aliexpress.com/item/1005005792534172.html
   - https://allegro.pl/oferta/pilot-atlo-rc4-tuya-zigbee-tuya-smart-da-16513965398

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -2845,7 +2845,7 @@ REMOTE_IHSENO_TS0044:
   tuya_module: ZT3L
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: mh9px7cq;TS0044-CUS;LC0;SD2u;SC2u;SC3u;SB4u;BTC4;M;
+  config_str: mh9px7cq;TS0044-CUS;LC0;SD2u;SC2u;SC3u;SB4u;BTD2;M;
   alt_config_str: null
   old_manufacturer_names: null
   old_zb_models: null
@@ -2853,8 +2853,8 @@ REMOTE_IHSENO_TS0044:
   stock_image_type: 54179
   firmware_image_type: 43563
   build: yes
-  status: in_progress
-  info: Battery Pin is not connected, so will always report 100%
+  status: fully_supported
+  info: Supported
   threads: 
    - https://github.com/romasku/tuya-zigbee-switch/issues/171
    - https://github.com/romasku/tuya-zigbee-switch/pull/395

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -2845,7 +2845,7 @@ REMOTE_IHSENO_TS0044:
   tuya_module: ZT3L
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: mh9px7cq;TS0044-CUS;LC0;SD2u;RD4;SC2u;RA0;SC3u;RD7;SB4u;RB5;M;
+  config_str: mh9px7cq;TS0044-CUS;LC0;SD2u;SC2u;SC3u;SB4u;BTC4;M;
   alt_config_str: null
   old_manufacturer_names: null
   old_zb_models: null
@@ -2854,7 +2854,7 @@ REMOTE_IHSENO_TS0044:
   firmware_image_type: 43563
   build: yes
   status: in_progress
-  info: Huge battery drain! Does not have relays.
+  info: Battery Pin is not connected, so will alway report 100%
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/171
   store:
   - https://www.aliexpress.com/item/1005005792534172.html


### PR DESCRIPTION
I've just onboarded some 4 button remotes (https://www.zigbee2mqtt.io/devices/TZ3000_mh9px7cq.html#ihseno-tz3000-mh9px7cq) and noticed the config is wrong

**Summary Of Changes**
- Remove relays - device has none
- Fix Switch 4 Pin - looks like the OG issue (https://github.com/romasku/tuya-zigbee-switch/issues/171
) miss traced the track, it looks like it goes to D7, but it actually runs under the module to B4
- Add BT parameter, to enable battery optimization - This appears to require a pin? I've assigned it the only ADC pin on the board C4, but nothing is connected, so I don't believe it is possible to get the battery level on this device.  (https://developer.tuya.com/en/docs/iot/zt3l-module-datasheet?id=Ka438n1j8nuvu#title-5-Pin%20definition)

---
P.S. This is my first contribution, so I want to say massive thanks for creating this custom firmware, it is excellent! and unlocks many options for a more decentralized smart home.