### PR TITLE
Add support for Moes 1-gang scene switch TS0041 ZT-B-EU1

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -3304,6 +3304,35 @@ REMOTE_LIDL_BUTTON_TS004F:
   info: Lower battery life
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/388
   store: null
+REMOTE_MOES_SWITCH_A_TS0041:
+  human_name: Moes 1-gang scene switch (multiple variants)
+  category: remote
+  power: CR2032
+  neutral: without
+  output: nothing
+  device_type: end_device
+  stock_model_name: TS0041
+  stock_manufacturer_name: _TZ3000_axpdxqgu
+  stock_converter_manufacturer: Moes
+  stock_converter_model: ZT-B-EU1
+  override_z2m_device: null
+  tuya_module: ZS3L
+  mcu_family: Silabs
+  mcu: EFR32MG21A020F768IM32
+  config_str: axpdxqgu;TS0041-MA;SA4u;IC1i;BTA0;M;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 45638
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: null
+  store:
+  - https://item.taobao.com/item.htm?id=702822677502
+  - https://www.aliexpress.com/item/1005004775774974.html
 REMOTE_MOES_SWITCH_A_TS0042:
   human_name: Moes 2-gang scene switch (multiple variants)
   category: remote

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -3329,7 +3329,7 @@ REMOTE_MOES_SWITCH_A_TS0041:
   build: yes
   status: fully_supported
   info: Supported
-  threads: null
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/429
   store:
   - https://item.taobao.com/item.htm?id=702822677502
   - https://www.aliexpress.com/item/1005004775774974.html


### PR DESCRIPTION
There is support for the battery-powered 2, 3 and 4-gang versions, so here’s one for the 1-gang scene switch.

Confirmed pinout by probing the pins using a multimeter and testing.

# Moes 1-gang scene switch ZT-B-EU1 (TS0041)
Z2M device link: 
https://www.zigbee2mqtt.io/devices/ZT-B-EU1.html

Model:
_TZ3000_axpdxqgu

Switch config: 
axpdxqgu;TS0041-MA;SA4u;IC1i;BTA0;M;

<img width="40%" alt="600269418-e3959c5f-a332-4841-a7f4-22e25d9b87cc" src="https://github.com/user-attachments/assets/60d6eb2f-17aa-46b2-90e1-d4c1cef38043" />
<img width="40%" alt="600269359-5b71460f-d05f-48aa-a896-31ba19a29cfb" src="https://github.com/user-attachments/assets/ad7e4576-2bc9-4308-8e2c-8ec58086edf6" />
<img width="80%" alt="600269291-c30724df-6829-4a06-9f0b-68a151518f63" src="https://github.com/user-attachments/assets/55051a26-5e6a-4dfb-b46a-a5e472aeb663" />
