### PR TITLE
Fix config for Moes 2-gang scene switch ZT-B-EU2 (TS0042)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -3319,7 +3319,7 @@ REMOTE_MOES_SWITCH_A_TS0042:
   tuya_module: ZS3L
   mcu_family: Silabs
   mcu: EFR32MG21A020F768IM32
-  config_str: 5e235jpa;TS0042-MA;SA0u;ID0i;SA4u;IC1i;BTA0;M;
+  config_str: 5e235jpa;TS0042-MA;SA0u;ID0i;SA3u;IC0i;BTA0;M;
   alt_config_str: null
   old_manufacturer_names: null
   old_zb_models: null


### PR DESCRIPTION
Support was added in https://github.com/romasku/tuya-zigbee-switch/commit/991e1d16431bdcbe66ad9e4d0e7561007f766e9b, but in particular for the 2-gang version, right button and LED doesn’t work. I see current pin config are simply assumed from the 3-gang version; I am updating the actual pin config for the right button and LED.

TS0042-MA
5e235jpa

## Pin change
Left button: A4 -> A3
Left LED: C1 -> C0

## Config
Previous
```
5e235jpa;TS0042-MA;SA0u;ID0i;SA4u;IC1i;BTA0;M;
```
New
```
5e235jpa;TS0042-MA;SA0u;ID0i;SA3u;IC0i;BTA0;M;
```

<img width="40%" alt="600288141-f0d0230a-6f89-4f3f-8f14-28ab674d37e8" src="https://github.com/user-attachments/assets/e9bf3470-5361-47d6-9a9f-1d6b01b6141a" />
<img width="40%" alt="600288104-8406c6f6-b457-47e8-9a4e-93698f694821" src="https://github.com/user-attachments/assets/c2673b42-0c5c-4c2b-a776-d96efa30a1ae" />
<img width="40%" alt="600288060-0104d99a-4173-4f0f-ad5c-dfc2b005a301" src="https://github.com/user-attachments/assets/3bfc8734-90ec-4819-b1bb-f4a04180d993" />
<img width="40%" alt="600288027-6b08ac83-4e2b-4e27-8396-51f85098977b" src="https://github.com/user-attachments/assets/6b6ddd34-7a70-44f0-a9ef-0c00f28b0378" />

