### PR TITLE
Add 5 ZTU-board switch modules (YBJ TS0003 + _TZ3210 variant, Milfra TS0002/TS0001/TS0004)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -5168,6 +5168,141 @@ SWITCH_MANHOT_B_TS0013:
   info: Supported
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/197
   store: https://www.aliexpress.com/item/1005006877282435.html
+SWITCH_MILFRA_TS0001:
+  human_name: Milfra 1-gang switch
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0001
+  stock_manufacturer_name: _TZ3000_gsqxcwqr
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0001
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: gsqxcwqr;TS0001-MIL;BC0u;LA0i;SC0u;RB4;IC4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47103
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
+SWITCH_MILFRA_TS0002:
+  human_name: Milfra 2-gang switch
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0002
+  stock_manufacturer_name: _TZ3210_mrigi9ij
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0002
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: ybjqjsuz;TS0002-YBJ;LA0i;SB6u;RB4;IA1i;SD3u;RD2;ID4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 2050
+  firmware_image_type: 47102
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
+SWITCH_MILFRA_TS0003:
+  human_name: Milfra 3-gang switch
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0003
+  stock_manufacturer_name: _TZ3000_ybjqjsuz
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0003
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: ybjqjsuz;TS0003-YBJ;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47100
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
+SWITCH_MILFRA_TS0003_1:
+  human_name: Milfra 3-gang switch
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0003
+  stock_manufacturer_name: _TZ3210_ybjqjsuz
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0003
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: ybjqjsuz;TS0003-YBJ;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 2050
+  firmware_image_type: 47101
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
+SWITCH_MILFRA_TS0004:
+  human_name: Milfra 4-gang switch
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0004
+  stock_manufacturer_name: _TZ3210_03vs3ks5
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0004
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: 03vs3ks5;TS0004-MIL;LA0i;SB6u;RC2;IA1i;SC0u;RC3;IC4i;SD7u;RD2;IC1i;SD3u;RB4;ID4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 2050
+  firmware_image_type: 47104
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
 SWITCH_MOES_ALL_TS0011:
   human_name: Moes 1-gang switches (all variants)
   category: switch
@@ -5789,142 +5924,3 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
 
-SWITCH_MILFRA_TS0003:
-  human_name: Milfra 3-gang switch
-  category: switch
-  power: mains
-  neutral: required
-  output: relay
-  device_type: router
-  stock_model_name: TS0003
-  stock_manufacturer_name: _TZ3000_ybjqjsuz
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0003
-  override_z2m_device: null
-  tuya_module: ZTU
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: ybjqjsuz;TS0003-YBJ;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 54179
-  firmware_image_type: 47100
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
-  store: https://www.aliexpress.com/item/1005010353623300.html
-
-SWITCH_MILFRA_TS0003_1:
-  human_name: Milfra 3-gang switch
-  category: switch
-  power: mains
-  neutral: required
-  output: relay
-  device_type: router
-  stock_model_name: TS0003
-  stock_manufacturer_name: _TZ3210_ybjqjsuz
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0003
-  override_z2m_device: null
-  tuya_module: ZTU
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: ybjqjsuz;TS0003-YBJ;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 2050
-  firmware_image_type: 47101
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
-  store: https://www.aliexpress.com/item/1005010353623300.html
-
-SWITCH_MILFRA_TS0002:
-  human_name: Milfra 2-gang switch
-  category: switch
-  power: mains
-  neutral: required
-  output: relay
-  device_type: router
-  stock_model_name: TS0002
-  stock_manufacturer_name: _TZ3210_mrigi9ij
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0002
-  override_z2m_device: null
-  tuya_module: ZTU
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: ybjqjsuz;TS0002-YBJ;LA0i;SB6u;RB4;IA1i;SD3u;RD2;ID4i;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 2050
-  firmware_image_type: 47102
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
-  store: https://www.aliexpress.com/item/1005010353623300.html
-
-SWITCH_MILFRA_TS0001:
-  human_name: Milfra 1-gang switch
-  category: switch
-  power: mains
-  neutral: required
-  output: relay
-  device_type: router
-  stock_model_name: TS0001
-  stock_manufacturer_name: _TZ3000_gsqxcwqr
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0001
-  override_z2m_device: null
-  tuya_module: ZTU
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: gsqxcwqr;TS0001-MIL;BC0u;LA0i;SC0u;RB4;IC4i;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 54179
-  firmware_image_type: 47103
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
-  store: https://www.aliexpress.com/item/1005010353623300.html
-
-SWITCH_MILFRA_TS0004:
-  human_name: Milfra 4-gang switch
-  category: switch
-  power: mains
-  neutral: required
-  output: relay
-  device_type: router
-  stock_model_name: TS0004
-  stock_manufacturer_name: _TZ3210_03vs3ks5
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0004
-  override_z2m_device: null
-  tuya_module: ZTU
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: 03vs3ks5;TS0004-MIL;LA0i;SB6u;RC2;IA1i;SC0u;RC3;IC4i;SD7u;RD2;IC1i;SD3u;RB4;ID4i;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 2050
-  firmware_image_type: 47104
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
-  store: https://www.aliexpress.com/item/1005010353623300.html

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -5788,3 +5788,144 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   info: Needs pinout. Secondary MCU. 6-gang!
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
+
+MODULE_YBJQJSUZ_TS0003:
+  human_name: 3-gang switch module (ZTU, _TZ3000_ybjqjsuz)
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0003
+  stock_manufacturer_name: _TZ3000_ybjqjsuz
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0003_switch_module_2
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: ybjqjsuz;TS0003-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
+  alt_config_str: null
+  old_manufacturer_names:
+  - _TZ3000_nPGIPl5D
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47100
+  build: yes
+  status: mostly_supported
+  info: 3-gang switch module on Tuya ZTU board (6-button capable PCB). Pin mapping from stock firmware dump analysis. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=C0 R=D2 I=C4i, ch3 S=D3 R=C3 I=D4i.
+  threads: null
+  store: null
+
+MODULE_YBJQJSUZ_TS0003_TZ3210:
+  human_name: 3-gang switch module (ZTU, _TZ3210_ybjqjsuz variant)
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0003
+  stock_manufacturer_name: _TZ3210_ybjqjsuz
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0003_switch_module_2
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: ybjqjsuz;TS0003-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 2050
+  firmware_image_type: 47101
+  build: yes
+  status: mostly_supported
+  info: Same hardware and pinout as MODULE_YBJQJSUZ_TS0003 but stock module is from the _TZ3210_ family (stock image_type 2050 instead of 54179). Same config_str.
+  threads: null
+  store: null
+
+MODULE_MRIGI9IJ_TS0002:
+  human_name: 2-gang switch module (ZTU, _TZ3210_mrigi9ij)
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0002
+  stock_manufacturer_name: _TZ3210_mrigi9ij
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0002_basic
+  override_z2m_device: TS0002_basic_2
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: ybjqjsuz;TS0002-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SD3u;RD2;ID4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 2050
+  firmware_image_type: 47102
+  build: yes
+  status: mostly_supported
+  info: 2-gang switch on the same 6-button ZTU board as the 3-gang module. Pinout verified on hardware. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=D3 R=D2 I=D4i.
+  threads: null
+  store: null
+
+MODULE_GSQXCWQR_TS0001:
+  human_name: 1-gang switch module (ZTU, _TZ3000_gsqxcwqr)
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0001
+  stock_manufacturer_name: _TZ3000_gsqxcwqr
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0001_basic
+  override_z2m_device: TS0001_basic_1
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: gsqxcwqr;TS0001-MIL;BC0u;LA0i;SC0u;RB4;IC4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47103
+  build: yes
+  status: mostly_supported
+  info: 1-gang switch on the same 6-button ZTU board. Pinout verified physically on hardware. Single button is the middle channel (C0, also master), relay B4, indicator C4. Note the relay is B4 (not D2 nor C3).
+  threads: null
+  store: null
+
+MODULE_03VS3KS5_TS0004:
+  human_name: 4-gang switch module (ZTU, Milfra _TZ3210_03vs3ks5)
+  category: switch
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0004
+  stock_manufacturer_name: _TZ3210_03vs3ks5
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0004
+  override_z2m_device: null
+  tuya_module: ZTU
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: 03vs3ks5;TS0004-MIL;BB6u;LA0i;SB6u;RC2;IA1i;SC0u;RC3;IC4i;SD7u;RD2;IC1i;SD3u;RB4;ID4i;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 2050
+  firmware_image_type: 47104
+  build: yes
+  status: mostly_supported
+  info: 4-gang switch (Milfra) on the 6-button ZTU board. Pinout traced physically from PCB silkscreen N02B/04B CTRL V0.2. master B6, net LED A0i; ch1 S=B6 R=C2 I=A1i, ch2 S=C0 R=C3 I=C4i, ch3 S=D7 R=D2 I=C1i, ch4 S=D3 R=B4 I=D4i.
+  threads: null
+  store: null

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -5789,8 +5789,8 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
 
-MODULE_YBJQJSUZ_TS0003:
-  human_name: 3-gang switch module (ZTU, _TZ3000_ybjqjsuz)
+MODULE_MILFRA_TS0003:
+  human_name: Milfra 3-gang switch module (ZTU, _TZ3000_ybjqjsuz)
   category: switch
   power: mains
   neutral: required
@@ -5814,12 +5814,12 @@ MODULE_YBJQJSUZ_TS0003:
   firmware_image_type: 47100
   build: yes
   status: mostly_supported
-  info: 3-gang switch module on Tuya ZTU board (6-button capable PCB). Pin mapping from stock firmware dump analysis. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=C0 R=D2 I=C4i, ch3 S=D3 R=C3 I=D4i.
+  info: Milfra 3-gang switch module on Tuya ZTU board (6-button capable PCB). Pin mapping from stock firmware dump analysis. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=C0 R=D2 I=C4i, ch3 S=D3 R=C3 I=D4i.
   threads: null
-  store: null
+  store: https://es.aliexpress.com/item/1005010353623300.html
 
-MODULE_YBJQJSUZ_TS0003_TZ3210:
-  human_name: 3-gang switch module (ZTU, _TZ3210_ybjqjsuz variant)
+MODULE_MILFRA_TS0003_TZ3210:
+  human_name: Milfra 3-gang switch module (ZTU, _TZ3210_ybjqjsuz variant)
   category: switch
   power: mains
   neutral: required
@@ -5835,19 +5835,19 @@ MODULE_YBJQJSUZ_TS0003_TZ3210:
   mcu: TLSR8258
   config_str: ybjqjsuz;TS0003-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
   alt_config_str: null
-  old_manufacturer_names: null
+  old_manufacturer_names: None
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 2050
   firmware_image_type: 47101
   build: yes
   status: mostly_supported
-  info: Same hardware and pinout as MODULE_YBJQJSUZ_TS0003 but stock module is from the _TZ3210_ family (stock image_type 2050 instead of 54179). Same config_str.
+  info: Same hardware and pinout as MODULE_MILFRA_TS0003 but stock module is from the _TZ3210_ family (stock image_type 2050 instead of 54179). Same config_str.
   threads: null
-  store: null
+  store: https://es.aliexpress.com/item/1005010353623300.html
 
-MODULE_MRIGI9IJ_TS0002:
-  human_name: 2-gang switch module (ZTU, _TZ3210_mrigi9ij)
+MODULE_MILFRA_TS0002:
+  human_name: Milfra 2-gang switch module (ZTU, _TZ3210_mrigi9ij)
   category: switch
   power: mains
   neutral: required
@@ -5863,19 +5863,19 @@ MODULE_MRIGI9IJ_TS0002:
   mcu: TLSR8258
   config_str: ybjqjsuz;TS0002-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SD3u;RD2;ID4i;
   alt_config_str: null
-  old_manufacturer_names: null
+  old_manufacturer_names: None
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 2050
   firmware_image_type: 47102
   build: yes
   status: mostly_supported
-  info: 2-gang switch on the same 6-button ZTU board as the 3-gang module. Pinout verified on hardware. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=D3 R=D2 I=D4i.
+  info: Milfra 2-gang switch on the same 6-button ZTU board as the 3-gang module. Pinout verified on hardware. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=D3 R=D2 I=D4i.
   threads: null
-  store: null
+  store: https://es.aliexpress.com/item/1005010353623300.html
 
-MODULE_GSQXCWQR_TS0001:
-  human_name: 1-gang switch module (ZTU, _TZ3000_gsqxcwqr)
+MODULE_MILFRA_TS0001:
+  human_name: Milfra 1-gang switch module (ZTU, _TZ3000_gsqxcwqr)
   category: switch
   power: mains
   neutral: required
@@ -5891,19 +5891,19 @@ MODULE_GSQXCWQR_TS0001:
   mcu: TLSR8258
   config_str: gsqxcwqr;TS0001-MIL;BC0u;LA0i;SC0u;RB4;IC4i;
   alt_config_str: null
-  old_manufacturer_names: null
+  old_manufacturer_names: None
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 54179
   firmware_image_type: 47103
   build: yes
   status: mostly_supported
-  info: 1-gang switch on the same 6-button ZTU board. Pinout verified physically on hardware. Single button is the middle channel (C0, also master), relay B4, indicator C4. Note the relay is B4 (not D2 nor C3).
+  info: Milfra 1-gang switch on the same 6-button ZTU board. Pinout verified physically on hardware. Single button is the middle channel (C0, also master), relay B4, indicator C4. Note the relay is B4 (not D2 nor C3).
   threads: null
-  store: null
+  store: https://es.aliexpress.com/item/1005010353623300.html
 
-MODULE_03VS3KS5_TS0004:
-  human_name: 4-gang switch module (ZTU, Milfra _TZ3210_03vs3ks5)
+MODULE_MILFRA_TS0004:
+  human_name: Milfra 4-gang switch module (ZTU, _TZ3210_03vs3ks5)
   category: switch
   power: mains
   neutral: required
@@ -5919,13 +5919,13 @@ MODULE_03VS3KS5_TS0004:
   mcu: TLSR8258
   config_str: 03vs3ks5;TS0004-MIL;BB6u;LA0i;SB6u;RC2;IA1i;SC0u;RC3;IC4i;SD7u;RD2;IC1i;SD3u;RB4;ID4i;
   alt_config_str: null
-  old_manufacturer_names: null
+  old_manufacturer_names: None
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 2050
   firmware_image_type: 47104
   build: yes
   status: mostly_supported
-  info: 4-gang switch (Milfra) on the 6-button ZTU board. Pinout traced physically from PCB silkscreen N02B/04B CTRL V0.2. master B6, net LED A0i; ch1 S=B6 R=C2 I=A1i, ch2 S=C0 R=C3 I=C4i, ch3 S=D7 R=D2 I=C1i, ch4 S=D3 R=B4 I=D4i.
+  info: Milfra 4-gang switch on the 6-button ZTU board. Pinout traced physically from PCB silkscreen N02B/04B CTRL V0.2. master B6, net LED A0i; ch1 S=B6 R=C2 I=A1i, ch2 S=C0 R=C3 I=C4i, ch3 S=D7 R=D2 I=C1i, ch4 S=D3 R=B4 I=D4i.
   threads: null
-  store: null
+  store: https://es.aliexpress.com/item/1005010353623300.html

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -5789,8 +5789,8 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
 
-MODULE_MILFRA_TS0003:
-  human_name: Milfra 3-gang switch module (ZTU, _TZ3000_ybjqjsuz)
+SWITCH_MILFRA_TS0003:
+  human_name: Milfra 3-gang switch
   category: switch
   power: mains
   neutral: required
@@ -5799,27 +5799,26 @@ MODULE_MILFRA_TS0003:
   stock_model_name: TS0003
   stock_manufacturer_name: _TZ3000_ybjqjsuz
   stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0003_switch_module_2
+  stock_converter_model: TS0003
   override_z2m_device: null
   tuya_module: ZTU
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: ybjqjsuz;TS0003-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
+  config_str: ybjqjsuz;TS0003-YBJ;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
   alt_config_str: null
-  old_manufacturer_names:
-  - _TZ3000_nPGIPl5D
+  old_manufacturer_names: null
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 54179
   firmware_image_type: 47100
   build: yes
-  status: mostly_supported
-  info: Milfra 3-gang switch module on Tuya ZTU board (6-button capable PCB). Pin mapping from stock firmware dump analysis. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=C0 R=D2 I=C4i, ch3 S=D3 R=C3 I=D4i.
-  threads: null
-  store: https://es.aliexpress.com/item/1005010353623300.html
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
 
-MODULE_MILFRA_TS0003_TZ3210:
-  human_name: Milfra 3-gang switch module (ZTU, _TZ3210_ybjqjsuz variant)
+SWITCH_MILFRA_TS0003_1:
+  human_name: Milfra 3-gang switch
   category: switch
   power: mains
   neutral: required
@@ -5828,26 +5827,26 @@ MODULE_MILFRA_TS0003_TZ3210:
   stock_model_name: TS0003
   stock_manufacturer_name: _TZ3210_ybjqjsuz
   stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0003_switch_module_2
+  stock_converter_model: TS0003
   override_z2m_device: null
   tuya_module: ZTU
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: ybjqjsuz;TS0003-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
+  config_str: ybjqjsuz;TS0003-YBJ;LA0i;SB6u;RB4;IA1i;SC0u;RD2;IC4i;SD3u;RC3;ID4i;
   alt_config_str: null
-  old_manufacturer_names: None
+  old_manufacturer_names: null
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 2050
   firmware_image_type: 47101
   build: yes
-  status: mostly_supported
-  info: Same hardware and pinout as MODULE_MILFRA_TS0003 but stock module is from the _TZ3210_ family (stock image_type 2050 instead of 54179). Same config_str.
-  threads: null
-  store: https://es.aliexpress.com/item/1005010353623300.html
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
 
-MODULE_MILFRA_TS0002:
-  human_name: Milfra 2-gang switch module (ZTU, _TZ3210_mrigi9ij)
+SWITCH_MILFRA_TS0002:
+  human_name: Milfra 2-gang switch
   category: switch
   power: mains
   neutral: required
@@ -5856,26 +5855,26 @@ MODULE_MILFRA_TS0002:
   stock_model_name: TS0002
   stock_manufacturer_name: _TZ3210_mrigi9ij
   stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0002_basic
-  override_z2m_device: TS0002_basic_2
+  stock_converter_model: TS0002
+  override_z2m_device: null
   tuya_module: ZTU
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: ybjqjsuz;TS0002-YBJ;BB6u;LA0i;SB6u;RB4;IA1i;SD3u;RD2;ID4i;
+  config_str: ybjqjsuz;TS0002-YBJ;LA0i;SB6u;RB4;IA1i;SD3u;RD2;ID4i;
   alt_config_str: null
-  old_manufacturer_names: None
+  old_manufacturer_names: null
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 2050
   firmware_image_type: 47102
   build: yes
-  status: mostly_supported
-  info: Milfra 2-gang switch on the same 6-button ZTU board as the 3-gang module. Pinout verified on hardware. master B6, net LED A0i; ch1 S=B6 R=B4 I=A1i, ch2 S=D3 R=D2 I=D4i.
-  threads: null
-  store: https://es.aliexpress.com/item/1005010353623300.html
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
 
-MODULE_MILFRA_TS0001:
-  human_name: Milfra 1-gang switch module (ZTU, _TZ3000_gsqxcwqr)
+SWITCH_MILFRA_TS0001:
+  human_name: Milfra 1-gang switch
   category: switch
   power: mains
   neutral: required
@@ -5884,26 +5883,26 @@ MODULE_MILFRA_TS0001:
   stock_model_name: TS0001
   stock_manufacturer_name: _TZ3000_gsqxcwqr
   stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0001_basic
-  override_z2m_device: TS0001_basic_1
+  stock_converter_model: TS0001
+  override_z2m_device: null
   tuya_module: ZTU
   mcu_family: Telink
   mcu: TLSR8258
   config_str: gsqxcwqr;TS0001-MIL;BC0u;LA0i;SC0u;RB4;IC4i;
   alt_config_str: null
-  old_manufacturer_names: None
+  old_manufacturer_names: null
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 54179
   firmware_image_type: 47103
   build: yes
-  status: mostly_supported
-  info: Milfra 1-gang switch on the same 6-button ZTU board. Pinout verified physically on hardware. Single button is the middle channel (C0, also master), relay B4, indicator C4. Note the relay is B4 (not D2 nor C3).
-  threads: null
-  store: https://es.aliexpress.com/item/1005010353623300.html
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html
 
-MODULE_MILFRA_TS0004:
-  human_name: Milfra 4-gang switch module (ZTU, _TZ3210_03vs3ks5)
+SWITCH_MILFRA_TS0004:
+  human_name: Milfra 4-gang switch
   category: switch
   power: mains
   neutral: required
@@ -5917,15 +5916,15 @@ MODULE_MILFRA_TS0004:
   tuya_module: ZTU
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: 03vs3ks5;TS0004-MIL;BB6u;LA0i;SB6u;RC2;IA1i;SC0u;RC3;IC4i;SD7u;RD2;IC1i;SD3u;RB4;ID4i;
+  config_str: 03vs3ks5;TS0004-MIL;LA0i;SB6u;RC2;IA1i;SC0u;RC3;IC4i;SD7u;RD2;IC1i;SD3u;RB4;ID4i;
   alt_config_str: null
-  old_manufacturer_names: None
+  old_manufacturer_names: null
   old_zb_models: null
   stock_manufacturer_id: 4417
   stock_image_type: 2050
   firmware_image_type: 47104
   build: yes
-  status: mostly_supported
-  info: Milfra 4-gang switch on the 6-button ZTU board. Pinout traced physically from PCB silkscreen N02B/04B CTRL V0.2. master B6, net LED A0i; ch1 S=B6 R=C2 I=A1i, ch2 S=C0 R=C3 I=C4i, ch3 S=D7 R=D2 I=C1i, ch4 S=D3 R=B4 I=D4i.
-  threads: null
-  store: https://es.aliexpress.com/item/1005010353623300.html
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/431
+  store: https://www.aliexpress.com/item/1005010353623300.html


### PR DESCRIPTION
Adds `device_db.yaml` entries for five Tuya **ZTU-board** (6-button-capable PCB) in-wall switch modules. All are **Telink TLSR8258**, mains/neutral, and their pinouts were **verified on real hardware** (in daily use via OTA-flashed custom firmware).

## Modules

| Module | manufacturerName | model | gangs |
|---|---|---|---|
| `MODULE_YBJQJSUZ_TS0003` | `_TZ3000_ybjqjsuz` (+ `_TZ3000_nPGIPl5D`) | TS0003 | 3 |
| `MODULE_YBJQJSUZ_TS0003_TZ3210` | `_TZ3210_ybjqjsuz` | TS0003 | 3 |
| `MODULE_MRIGI9IJ_TS0002` | `_TZ3210_mrigi9ij` | TS0002 | 2 |
| `MODULE_GSQXCWQR_TS0001` | `_TZ3000_gsqxcwqr` | TS0001 | 1 |
| `MODULE_03VS3KS5_TS0004` | `_TZ3210_03vs3ks5` | TS0004 | 4 (Milfra) |

They all share the same 6-button ZTU PCB. Pinouts (master `B6`, net LED `A0` inverted):
- **TS0004 (4-gang):** ch1 S=B6/R=C2/I=A1, ch2 S=C0/R=C3/I=C4, ch3 S=D7/R=D2/I=C1, ch4 S=D3/R=B4/I=D4 — traced physically from PCB silkscreen `N02B/04B CTRL V0.2`.
- **TS0003 (3-gang):** ch1 S=B6/R=B4/I=A1, ch2 S=C0/R=D2/I=C4, ch3 S=D3/R=C3/I=D4 — from stock firmware dump analysis.
- **TS0002 (2-gang):** ch1 S=B6/R=B4/I=A1, ch2 S=D3/R=D2/I=D4.
- **TS0001 (1-gang):** single button = middle channel S=C0 (also master), R=**B4**, I=C4. (Relay is B4 — not the 3-gang ch2 D2 nor the 4-gang ch2 C3; verified physically.)

The `_TZ3210_*` variants share the exact same hardware/pinout as their `_TZ3000_*` counterparts but use stock `image_type` 2050 instead of 54179.

## Notes
- `firmware_image_type` assigned to free values **47100–47104** (no collision with existing entries; please reassign if you prefer).
- Module names follow the chip suffix; happy to rename to a brand convention (these appear to be **Milfra**-branded modules) if you prefer.
- Only `device_db.yaml` is touched. Built & tested via the fork's `build.yml` + OTA before submitting.