### PR TITLE
Add tests for toggle_mode and relay-less devices

### DIFF
--- a/tests/test_switch_cluster_toggle_mode.py
+++ b/tests/test_switch_cluster_toggle_mode.py
@@ -11,7 +11,13 @@ from tests.zcl_consts import (
     ZCL_CMD_ONOFF_OFF,
     ZCL_CMD_ONOFF_ON,
     ZCL_CMD_ONOFF_TOGGLE,
+    ZCL_ONOFF_CONFIGURATION_BINDED_MODE_LONG,
+    ZCL_ONOFF_CONFIGURATION_BINDED_MODE_RISE,
+    ZCL_ONOFF_CONFIGURATION_BINDED_MODE_SHORT,
     ZCL_ONOFF_CONFIGURATION_RELAY_MODE_DETACHED,
+    ZCL_ONOFF_CONFIGURATION_RELAY_MODE_LONG,
+    ZCL_ONOFF_CONFIGURATION_RELAY_MODE_RISE,
+    ZCL_ONOFF_CONFIGURATION_RELAY_MODE_SHORT,
     ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_OFFON,
     ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_ONOFF,
     ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_TOGGLE_SIMPLE,
@@ -134,14 +140,38 @@ def test_toggle_mode_offon_actions_relay_control(
     assert toggle_device.get_gpio(relay_button_pair.relay_pin) == 0
 
 
+@pytest.mark.parametrize(
+    "pause_ms",
+    [
+        pytest.param(0, id="short"),
+        pytest.param(1_000, id="long"),
+    ],
+)
+@pytest.mark.parametrize(
+    "binded_mode",
+    [
+        pytest.param(ZCL_ONOFF_CONFIGURATION_BINDED_MODE_RISE, id="rise"),
+        pytest.param(ZCL_ONOFF_CONFIGURATION_BINDED_MODE_SHORT, id="short"),
+        pytest.param(ZCL_ONOFF_CONFIGURATION_BINDED_MODE_LONG, id="long"),
+    ],
+)
 def test_toggle_mode_toggle_actions_commands(
-    toggle_device: Device, relay_button_pair: RelayButtonPair
+    toggle_device: Device,
+    relay_button_pair: RelayButtonPair,
+    binded_mode: int,
+    pause_ms: int,
 ):
+    """Toggle mode is edges-only: action=TOGGLE_SIMPLE emits Toggle on press
+    and on release, nothing in between, regardless of binded_mode (a Momentary-
+    only setting) and hold duration."""
     toggle_device.write_zigbee_attr(
         relay_button_pair.switch_endpoint,
         ZCL_CLUSTER_ON_OFF_SWITCH_CONFIG,
         ZCL_ATTR_ONOFF_CONFIGURATION_SWITCH_ACTIONS,
         ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_TOGGLE_SIMPLE,
+    )
+    toggle_device.zcl_switch_binding_mode_set(
+        relay_button_pair.switch_endpoint, binded_mode
     )
 
     toggle_device.press_button(relay_button_pair.button_pin)
@@ -149,6 +179,11 @@ def test_toggle_mode_toggle_actions_commands(
     toggle_device.wait_for_cmd_send(
         relay_button_pair.switch_endpoint, ZCL_CLUSTER_ON_OFF, ZCL_CMD_ONOFF_TOGGLE
     )
+
+    # Hold for any duration — no extra emit.
+    toggle_device.clear_events()
+    toggle_device.step_time(pause_ms)
+    assert toggle_device.zcl_list_cmds(cluster=ZCL_CLUSTER_ON_OFF) == []
 
     toggle_device.release_button(relay_button_pair.button_pin)
 
@@ -284,6 +319,46 @@ def test_relay_not_controlled_if_detached(
     toggle_device.release_button(relay_button_pair.button_pin)
     assert toggle_device.zcl_relay_get(relay_button_pair.relay_endpoint) == "1"
     assert toggle_device.get_gpio(relay_button_pair.relay_pin) == 1
+
+
+@pytest.mark.parametrize(
+    "pause_ms",
+    [
+        pytest.param(0, id="short"),
+        pytest.param(1_000, id="long"),
+    ],
+)
+@pytest.mark.parametrize(
+    "relay_mode",
+    [
+        pytest.param(ZCL_ONOFF_CONFIGURATION_RELAY_MODE_RISE, id="rise"),
+        pytest.param(ZCL_ONOFF_CONFIGURATION_RELAY_MODE_SHORT, id="short"),
+        pytest.param(ZCL_ONOFF_CONFIGURATION_RELAY_MODE_LONG, id="long"),
+    ],
+)
+def test_toggle_mode_relay_mode_flips_only_on_edges(
+    toggle_device: Device,
+    relay_button_pair: RelayButtonPair,
+    relay_mode: int,
+    pause_ms: int,
+):
+    """Toggle mode is edges-only: relay flips on press and on release, nothing
+    in between, regardless of relay_mode (a Momentary-only setting) and hold
+    duration."""
+    toggle_device.zcl_switch_relay_mode_set(
+        relay_button_pair.switch_endpoint, relay_mode
+    )
+
+    toggle_device.press_button(relay_button_pair.button_pin)
+    relay_after_press = toggle_device.zcl_relay_get(relay_button_pair.relay_endpoint)
+
+    # Hold for any duration — relay stays put.
+    toggle_device.step_time(pause_ms)
+    assert toggle_device.zcl_relay_get(relay_button_pair.relay_endpoint) == relay_after_press
+
+    # Release flips back.
+    toggle_device.release_button(relay_button_pair.button_pin)
+    assert toggle_device.zcl_relay_get(relay_button_pair.relay_endpoint) != relay_after_press
 
 
 # Test multistate state

--- a/tests/test_switches_without_relays.py
+++ b/tests/test_switches_without_relays.py
@@ -11,11 +11,16 @@ from zcl_consts import (
     ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
     ZCL_CLUSTER_ON_OFF,
     ZCL_CLUSTER_ON_OFF_SWITCH_CONFIG,
+    ZCL_CMD_ONOFF_OFF,
+    ZCL_CMD_ONOFF_ON,
     ZCL_CMD_ONOFF_TOGGLE,
     ZCL_ONOFF_CONFIGURATION_BINDED_MODE_LONG,
     ZCL_ONOFF_CONFIGURATION_BINDED_MODE_RISE,
     ZCL_ONOFF_CONFIGURATION_BINDED_MODE_SHORT,
     ZCL_ONOFF_CONFIGURATION_RELAY_MODE_DETACHED,
+    ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_OFFON,
+    ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_ONOFF,
+    ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_TOGGLE_SIMPLE,
     ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_TOGGLE_SMART_OPPOSITE,
     ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_TOGGLE_SMART_SYNC,
     ZCL_ONOFF_CONFIGURATION_SWITCH_TYPE_MOMENTARY,
@@ -55,7 +60,7 @@ def test_relay_index_is_zero(device: Device):
         assert idx == 0
 
 
-def test_button_press_no_crash(device: Device, button_pins: list[str]):
+def test_button_press_multistate(device: Device, button_pins: list[str]):
     """Pressing buttons does not crash and multistate value changes."""
     for i, pin in enumerate(button_pins):
         ep = i + 1
@@ -66,20 +71,68 @@ def test_button_press_no_crash(device: Device, button_pins: list[str]):
         assert val is not None
 
 
-def test_long_press_no_crash(device: Device, button_pins: list[str]):
-    """Long-pressing buttons does not crash when no relays are bound."""
-    for pin in button_pins:
+def test_button_press_no_crash(device: Device, button_pins: list[str]):
+    """Short-click and long-press on every button do not crash."""
+    for i, pin in enumerate(button_pins):
+        device.zcl_switch_mode_set(i + 1, ZCL_ONOFF_CONFIGURATION_SWITCH_TYPE_MOMENTARY)
+        device.click_button(pin) 
         device.long_click_button(pin, duration_ms=1000)
-    # If we got here without crash, the test passes
+    # If we got here without crash, the device is still responsive.
     assert device.read_zigbee_attr(1, ZCL_CLUSTER_BASIC, ZCL_ATTR_BASIC_MFR_NAME) is not None
 
 
-def test_binding_commands_still_sent(device: Device, button_pins: list[str]):
-    """After joining network, button press still emits binding commands."""
-    device.set_network(1)  # joined
+@pytest.mark.parametrize(
+    "action,expected_cmd",
+    [
+        pytest.param(
+            ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_TOGGLE_SIMPLE,
+            ZCL_CMD_ONOFF_TOGGLE,
+            id="toggle",
+        ),
+        pytest.param(
+            ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_ONOFF, ZCL_CMD_ONOFF_ON, id="on"
+        ),
+        pytest.param(
+            ZCL_ONOFF_CONFIGURATION_SWITCH_ACTION_OFFON, ZCL_CMD_ONOFF_OFF, id="off"
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "binded_mode,trigger",
+    [
+        pytest.param(
+            ZCL_ONOFF_CONFIGURATION_BINDED_MODE_RISE,
+            lambda d, pin: d.press_button(pin),
+            id="rise",
+        ),
+        pytest.param(
+            ZCL_ONOFF_CONFIGURATION_BINDED_MODE_SHORT,
+            lambda d, pin: d.click_button(pin),
+            id="short",
+        ),
+        pytest.param(
+            ZCL_ONOFF_CONFIGURATION_BINDED_MODE_LONG,
+            lambda d, pin: d.long_click_button(pin, duration_ms=1000),
+            id="long",
+        ),
+    ],
+)
+def test_binding_commands_still_sent(
+    device: Device,
+    button_pins: list[str],
+    binded_mode: int,
+    trigger,
+    action: int,
+    expected_cmd: int,
+):
+    """All binded_modes × SwitchActions emit the right OnOff command on press."""
+    device.zcl_switch_mode_set(1, ZCL_ONOFF_CONFIGURATION_SWITCH_TYPE_MOMENTARY)
+    device.zcl_switch_binding_mode_set(1, binded_mode)
+    device.zcl_switch_actions_set(1, action)
+    device.set_network(1)
     device.clear_events()
-    device.click_button(button_pins[0])
-    device.wait_for_cmd_send(1, ZCL_CLUSTER_ON_OFF, ZCL_CMD_ONOFF_TOGGLE)
+    trigger(device, button_pins[0])
+    device.wait_for_cmd_send(1, ZCL_CLUSTER_ON_OFF, expected_cmd)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Continue adding tests to make further refactor solid:

- `test_switch_cluster_toggle_mode.py`:
  - extend `test_toggle_mode_toggle_actions_commands` with binded_mode × hold-duration parametrise to assert edges-only emission
  - add `test_toggle_mode_relay_mode_flips_only_on_edges` to ensure OnOffCluster doesn't affect relay on long press

- `test_switches_without_relays.py`:
  - rename `test_button_press_no_crash` to `test_button_press_multistate` (content unchanged)
  - replace `test_long_press_no_crash` with `test_button_press_no_crash`: added both short-click and long-press each button in sequence in Momentary mode
  - parametrise `test_binding_commands_still_sent` over binded_mode (RISE/SHORT/LONG) × SwitchActions (TOGGLE_SIMPLE/ONOFF/OFFON)