### PR TITLE
Add dimmer key based on two buttons

### DIFF
--- a/src/device_config/config_parser.c
+++ b/src/device_config/config_parser.c
@@ -6,6 +6,7 @@
 #include "zigbee/consts.h"
 #include "zigbee/cover_cluster.h"
 #include "zigbee/cover_switch_cluster.h"
+#include "zigbee/dimmer_key_cluster.h"
 #include "zigbee/group_cluster.h"
 #include "zigbee/relay_cluster.h"
 #include "zigbee/poll_control_cluster.h"
@@ -61,6 +62,9 @@ uint8_t cover_switch_clusters_cnt = 0;
 
 zigbee_cover_cluster cover_clusters[3];
 uint8_t cover_clusters_cnt = 0;
+
+zigbee_dimmer_key_cluster dimmer_key_clusters[2];
+uint8_t dimmer_key_clusters_cnt = 0;
 
 hal_zigbee_cluster  clusters[32];
 hal_zigbee_endpoint endpoints[10];
@@ -259,6 +263,32 @@ void parse_config() {
             cover_switch_clusters[cover_switch_clusters_cnt].cover_switch_idx =
                 cover_switch_clusters_cnt;
             cover_switch_clusters_cnt++;
+        } else if (entry[0] == 'K') {
+            hal_gpio_pin_t  up_pin   = hal_gpio_parse_pin(entry + 1);
+            hal_gpio_pin_t  down_pin = hal_gpio_parse_pin(entry + 3);
+            hal_gpio_pull_t pull     = hal_gpio_parse_pull(entry + 5);
+
+            hal_gpio_init(up_pin, 1, pull);
+            hal_gpio_init(down_pin, 1, pull);
+
+            buttons[buttons_cnt].pin = up_pin;
+            buttons[buttons_cnt].long_press_duration_ms  = 800;
+            buttons[buttons_cnt].multi_press_duration_ms = 800;
+            buttons[buttons_cnt].debounce_delay_ms       = debounce_ms;
+            buttons[buttons_cnt].on_multi_press          = on_multi_press_reset;
+            button_t *up_button = &buttons[buttons_cnt++];
+
+            buttons[buttons_cnt].pin = down_pin;
+            buttons[buttons_cnt].long_press_duration_ms  = 800;
+            buttons[buttons_cnt].multi_press_duration_ms = 800;
+            buttons[buttons_cnt].debounce_delay_ms       = debounce_ms;
+            buttons[buttons_cnt].on_multi_press          = on_multi_press_reset;
+            button_t *down_button = &buttons[buttons_cnt++];
+
+            dimmer_key_clusters[dimmer_key_clusters_cnt].up_button      = up_button;
+            dimmer_key_clusters[dimmer_key_clusters_cnt].down_button    = down_button;
+            dimmer_key_clusters[dimmer_key_clusters_cnt].dimmer_key_idx = dimmer_key_clusters_cnt;
+            dimmer_key_clusters_cnt++;
         } else if (entry[0] == 'C') {
             hal_gpio_pin_t open_pin  = hal_gpio_parse_pin(entry + 1);
             hal_gpio_pin_t close_pin = hal_gpio_parse_pin(entry + 3);
@@ -294,12 +324,13 @@ void parse_config() {
     peripherals_init();
 
     printf("Initializing Zigbee with %d switches, %d relays, %d cover switches, "
-           "%d covers\r\n",
+           "%d covers, %d dimmer keys\r\n",
            switch_clusters_cnt, relay_clusters_cnt, cover_switch_clusters_cnt,
-           cover_clusters_cnt);
+           cover_clusters_cnt, dimmer_key_clusters_cnt);
 
     uint8_t total_endpoints = switch_clusters_cnt + relay_clusters_cnt +
-                              cover_switch_clusters_cnt + cover_clusters_cnt;
+                              cover_switch_clusters_cnt + cover_clusters_cnt +
+                              dimmer_key_clusters_cnt;
 
     hal_zigbee_cluster *cluster_ptr = clusters;
 
@@ -382,6 +413,17 @@ void parse_config() {
         }
         cover_cluster_add_to_endpoint(&cover_clusters[index],
                                       &endpoints[cover_base + index]);
+    }
+
+    int dimmer_key_base =
+        switch_clusters_cnt + relay_clusters_cnt + cover_switch_clusters_cnt + cover_clusters_cnt;
+    for (int index = 0; index < dimmer_key_clusters_cnt; index++) {
+        if (dimmer_key_base + index != 0) {
+            cluster_ptr += endpoints[dimmer_key_base + index - 1].cluster_count;
+            endpoints[dimmer_key_base + index].clusters = cluster_ptr;
+        }
+        dimmer_key_cluster_add_to_endpoint(&dimmer_key_clusters[index],
+                                           &endpoints[dimmer_key_base + index]);
     }
 
     hal_zigbee_init(endpoints, total_endpoints);

--- a/src/device_config/nvm_items.h
+++ b/src/device_config/nvm_items.h
@@ -22,8 +22,9 @@
         (NV_ITEM_BASIC_CLUSTER_DATA + MAX_SWITCHES + MAX_RELAYS + MAX_COVER_SWITCHES + 1 + \
          cover_idx)
 
-#define NV_ITEM_DIMMER_KEY_CONFIG(dimmer_key_idx)                                                          \
-        (NV_ITEM_BASIC_CLUSTER_DATA + MAX_SWITCHES + MAX_RELAYS + MAX_COVER_SWITCHES + MAX_COVERS + 1 +    \
+#define NV_ITEM_DIMMER_KEY_CONFIG(dimmer_key_idx)                                                   \
+        (NV_ITEM_BASIC_CLUSTER_DATA + MAX_SWITCHES + MAX_RELAYS + MAX_COVER_SWITCHES + MAX_COVERS + \
+         1 +                                                                                        \
          dimmer_key_idx)
 
 // 3 + 5 (switches) + 5 (relays) + 3 (cover switches) + 3 (covers) + 2 (dimmer keys) = 21

--- a/src/device_config/nvm_items.h
+++ b/src/device_config/nvm_items.h
@@ -5,6 +5,7 @@
 #define MAX_SWITCHES                     5
 #define MAX_COVER_SWITCHES               3
 #define MAX_COVERS                       3
+#define MAX_DIMMER_KEYS                  2
 
 #define NV_ITEM_CURRENT_VERSION_IN_NV    1
 #define NV_ITEM_DEVICE_CONFIG            2
@@ -21,7 +22,11 @@
         (NV_ITEM_BASIC_CLUSTER_DATA + MAX_SWITCHES + MAX_RELAYS + MAX_COVER_SWITCHES + 1 + \
          cover_idx)
 
-// 3 + 5 (switches) + 5 (relays) + 3 (cover switches) + 3 (covers) = 19
+#define NV_ITEM_DIMMER_KEY_CONFIG(dimmer_key_idx)                                                          \
+        (NV_ITEM_BASIC_CLUSTER_DATA + MAX_SWITCHES + MAX_RELAYS + MAX_COVER_SWITCHES + MAX_COVERS + 1 +    \
+         dimmer_key_idx)
+
+// 3 + 5 (switches) + 5 (relays) + 3 (cover switches) + 3 (covers) + 2 (dimmer keys) = 21
 // Adding room for future items, so starting from 32
 #define NV_ITEM_DEVICE_TYPE                32
 

--- a/src/silabs/slcp_files/zigbee.slcp
+++ b/src/silabs/slcp_files/zigbee.slcp
@@ -56,6 +56,7 @@ source:
 - {path: ../../zigbee/switch_cluster.c}
 - {path: ../../zigbee/cover_switch_cluster.c}
 - {path: ../../zigbee/cover_cluster.c}
+- {path: ../../zigbee/dimmer_key_cluster.c}
 - {path: ../../zigbee/battery_cluster.h}
 - {path: ../../zigbee/basic_cluster.h}
 - {path: ../../zigbee/cluster_common.h}
@@ -65,6 +66,7 @@ source:
 - {path: ../../zigbee/switch_cluster.h}
 - {path: ../../zigbee/cover_switch_cluster.h}
 - {path: ../../zigbee/cover_cluster.h}
+- {path: ../../zigbee/dimmer_key_cluster.h}
 - {path: ../../zigbee/zigbee_commands.h}
 - {path: ../../zigbee/general_commands.h}
 - {path: ../../zigbee/group_cluster.h}

--- a/src/silabs/slcp_files/zigbee_end_device.slcp
+++ b/src/silabs/slcp_files/zigbee_end_device.slcp
@@ -56,6 +56,7 @@ source:
 - {path: ../../zigbee/switch_cluster.c}
 - {path: ../../zigbee/cover_switch_cluster.c}
 - {path: ../../zigbee/cover_cluster.c}
+- {path: ../../zigbee/dimmer_key_cluster.c}
 - {path: ../../zigbee/battery_cluster.h}
 - {path: ../../zigbee/basic_cluster.h}
 - {path: ../../zigbee/cluster_common.h}
@@ -65,6 +66,7 @@ source:
 - {path: ../../zigbee/switch_cluster.h}
 - {path: ../../zigbee/cover_switch_cluster.h}
 - {path: ../../zigbee/cover_cluster.h}
+- {path: ../../zigbee/dimmer_key_cluster.h}
 - {path: ../../zigbee/zigbee_commands.h}
 - {path: ../../zigbee/general_commands.h}
 - {path: ../../zigbee/group_cluster.h}

--- a/src/stub/Makefile
+++ b/src/stub/Makefile
@@ -64,7 +64,8 @@ SOURCES := \
 	$(SRC_DIR)/zigbee/general_commands.c \
 	$(SRC_DIR)/zigbee/cover_switch_cluster.c \
 	$(SRC_DIR)/zigbee/cover_cluster.c \
-	$(SRC_DIR)/zigbee/battery_cluster.c
+	$(SRC_DIR)/zigbee/battery_cluster.c \
+	$(SRC_DIR)/zigbee/dimmer_key_cluster.c
 
 INCLUDES := \
 	-I$(SRC_DIR) \

--- a/src/telink/Makefile
+++ b/src/telink/Makefile
@@ -163,7 +163,8 @@ COMMON_SOURCES := \
 	$(SRC_DIR)/zigbee/switch_cluster.c \
 	$(SRC_DIR)/zigbee/cover_switch_cluster.c \
 	$(SRC_DIR)/zigbee/cover_cluster.c \
-	$(SRC_DIR)/zigbee/battery_cluster.c 
+	$(SRC_DIR)/zigbee/battery_cluster.c \
+	$(SRC_DIR)/zigbee/dimmer_key_cluster.c
 
 # All application sources
 ALL_TELINK_SOURCES := $(TELINK_SOURCES) $(COMMON_SOURCES)

--- a/src/zigbee/consts.h
+++ b/src/zigbee/consts.h
@@ -104,8 +104,8 @@
 #define ZCL_ATTR_COVER_SWITCH_CONFIG_LONG_PRESS_DUR                  0x0005
 
 // Dimmer Key Configuration cluster (manufacturer-specific)
-#define ZCL_ATTR_DIMMER_KEY_CONFIG_LONG_PRESS_DUR     0x0000
-#define ZCL_ATTR_DIMMER_KEY_CONFIG_LEVEL_MOVE_RATE    0x0001
+#define ZCL_ATTR_DIMMER_KEY_CONFIG_LONG_PRESS_DUR                    0x0000
+#define ZCL_ATTR_DIMMER_KEY_CONFIG_LEVEL_MOVE_RATE                   0x0001
 
 // Poll Control cluster
 #define ZCL_CLUSTER_POLL_CONTROL                                     0x0020

--- a/src/zigbee/consts.h
+++ b/src/zigbee/consts.h
@@ -16,6 +16,7 @@
 #define ZCL_CLUSTER_OTA_BOOTLOAD              0x0019
 #define ZCL_CLUSTER_WINDOW_COVERING           0x0102
 #define ZCL_CLUSTER_COVER_SWITCH_CONFIG       0xFC01
+#define ZCL_CLUSTER_DIMMER_KEY_CONFIG         0xFC02
 
 
 // Attributes
@@ -101,6 +102,10 @@
 #define ZCL_ATTR_COVER_SWITCH_CONFIG_LOCAL_MODE                      0x0003
 #define ZCL_ATTR_COVER_SWITCH_CONFIG_BINDED_MODE                     0x0004
 #define ZCL_ATTR_COVER_SWITCH_CONFIG_LONG_PRESS_DUR                  0x0005
+
+// Dimmer Key Configuration cluster (manufacturer-specific)
+#define ZCL_ATTR_DIMMER_KEY_CONFIG_LONG_PRESS_DUR     0x0000
+#define ZCL_ATTR_DIMMER_KEY_CONFIG_LEVEL_MOVE_RATE    0x0001
 
 // Poll Control cluster
 #define ZCL_CLUSTER_POLL_CONTROL                                     0x0020

--- a/src/zigbee/dimmer_key_cluster.c
+++ b/src/zigbee/dimmer_key_cluster.c
@@ -1,0 +1,235 @@
+#include "dimmer_key_cluster.h"
+#include "cluster_common.h"
+#include "consts.h"
+#include "device_config/nvm_items.h"
+#include "hal/nvm.h"
+#include "hal/printf_selector.h"
+#include "hal/zigbee.h"
+#include "zigbee_commands.h"
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+#define MULTISTATE_RELEASED     0
+#define MULTISTATE_UP_PRESS     1
+#define MULTISTATE_DOWN_PRESS   2
+#define MULTISTATE_UP_LONG      3
+#define MULTISTATE_DOWN_LONG    4
+
+static const uint8_t  multistate_out_of_service = 0;
+static const uint8_t  multistate_flags          = 0;
+static const uint16_t multistate_num_of_states  = 5;
+
+static zigbee_dimmer_key_cluster *      dimmer_key_cluster_by_endpoint[10];
+static zigbee_dimmer_key_cluster_config nv_config_buffer;
+
+// ============================================================================
+// NVM Persistence
+// ============================================================================
+
+static void dimmer_key_cluster_store_attrs_to_nv(zigbee_dimmer_key_cluster *cluster) {
+    nv_config_buffer.button_long_press_duration =
+        cluster->up_button->long_press_duration_ms;
+    nv_config_buffer.level_move_rate = cluster->level_move_rate;
+    hal_nvm_write(NV_ITEM_DIMMER_KEY_CONFIG(cluster->dimmer_key_idx),
+                  sizeof(zigbee_dimmer_key_cluster_config),
+                  (uint8_t *)&nv_config_buffer);
+}
+
+static void dimmer_key_cluster_load_attrs_from_nv(zigbee_dimmer_key_cluster *cluster) {
+    hal_nvm_status_t st = hal_nvm_read(
+        NV_ITEM_DIMMER_KEY_CONFIG(cluster->dimmer_key_idx),
+        sizeof(zigbee_dimmer_key_cluster_config),
+        (uint8_t *)&nv_config_buffer);
+
+    if (st != HAL_NVM_SUCCESS) {
+        printf("No dimmer key config in NV, using defaults\r\n");
+        return;
+    }
+
+    cluster->up_button->long_press_duration_ms   = nv_config_buffer.button_long_press_duration;
+    cluster->down_button->long_press_duration_ms = nv_config_buffer.button_long_press_duration;
+    cluster->level_move_rate                     = nv_config_buffer.level_move_rate;
+}
+
+// ============================================================================
+// Attribute Write Handler
+// ============================================================================
+
+static void dimmer_key_cluster_on_write_attr(zigbee_dimmer_key_cluster *cluster,
+                                             uint16_t attribute_id) {
+    if (attribute_id == ZCL_ATTR_DIMMER_KEY_CONFIG_LONG_PRESS_DUR) {
+        // Long press duration is shared between up and down buttons
+        cluster->down_button->long_press_duration_ms =
+            cluster->up_button->long_press_duration_ms;
+    }
+    dimmer_key_cluster_store_attrs_to_nv(cluster);
+}
+
+void dimmer_key_cluster_callback_attr_write_trampoline(uint8_t endpoint,
+                                                       uint16_t attribute_id) {
+    dimmer_key_cluster_on_write_attr(dimmer_key_cluster_by_endpoint[endpoint],
+                                     attribute_id);
+}
+
+// ============================================================================
+// Zigbee Command Helpers
+// ============================================================================
+
+static void send_onoff(zigbee_dimmer_key_cluster *cluster, uint8_t cmd_id) {
+    if (hal_zigbee_get_network_status() != HAL_ZIGBEE_NETWORK_JOINED) {
+        return;
+    }
+    hal_zigbee_cmd c = build_onoff_cmd(cluster->endpoint, cmd_id);
+    hal_zigbee_send_cmd_to_bindings(&c);
+}
+
+static void send_level_move(zigbee_dimmer_key_cluster *cluster, uint8_t direction) {
+    if (hal_zigbee_get_network_status() != HAL_ZIGBEE_NETWORK_JOINED) {
+        return;
+    }
+    hal_zigbee_cmd c = build_level_move_onoff_cmd(cluster->endpoint, direction,
+                                                  cluster->level_move_rate);
+    hal_zigbee_send_cmd_to_bindings(&c);
+}
+
+static void send_level_stop(zigbee_dimmer_key_cluster *cluster) {
+    if (hal_zigbee_get_network_status() != HAL_ZIGBEE_NETWORK_JOINED) {
+        return;
+    }
+    hal_zigbee_cmd c = build_level_stop_onoff_cmd(cluster->endpoint);
+    hal_zigbee_send_cmd_to_bindings(&c);
+}
+
+static void update_present_value(zigbee_dimmer_key_cluster *cluster,
+                                 uint16_t value) {
+    cluster->present_value = value;
+    hal_zigbee_notify_attribute_changed(cluster->endpoint,
+                                        ZCL_CLUSTER_MULTISTATE_INPUT_BASIC,
+                                        ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE);
+}
+
+// ============================================================================
+// Button Event Handlers
+// ============================================================================
+
+static void dimmer_key_cluster_on_up_press(zigbee_dimmer_key_cluster *cluster) {
+    update_present_value(cluster, MULTISTATE_UP_PRESS);
+}
+
+static void dimmer_key_cluster_on_up_long_press(zigbee_dimmer_key_cluster *cluster) {
+    update_present_value(cluster, MULTISTATE_UP_LONG);
+    send_level_move(cluster, ZCL_LEVEL_MOVE_UP);
+}
+
+static void dimmer_key_cluster_on_up_release(zigbee_dimmer_key_cluster *cluster) {
+    if (cluster->up_button->long_pressed) {
+        send_level_stop(cluster);
+    } else {
+        send_onoff(cluster, ZCL_CMD_ONOFF_ON);
+    }
+    update_present_value(cluster, MULTISTATE_RELEASED);
+}
+
+static void dimmer_key_cluster_on_down_press(zigbee_dimmer_key_cluster *cluster) {
+    update_present_value(cluster, MULTISTATE_DOWN_PRESS);
+}
+
+static void dimmer_key_cluster_on_down_long_press(zigbee_dimmer_key_cluster *cluster) {
+    update_present_value(cluster, MULTISTATE_DOWN_LONG);
+    send_level_move(cluster, ZCL_LEVEL_MOVE_DOWN);
+}
+
+static void dimmer_key_cluster_on_down_release(zigbee_dimmer_key_cluster *cluster) {
+    if (cluster->down_button->long_pressed) {
+        send_level_stop(cluster);
+    } else {
+        send_onoff(cluster, ZCL_CMD_ONOFF_OFF);
+    }
+    update_present_value(cluster, MULTISTATE_RELEASED);
+}
+
+// ============================================================================
+// Initialization
+// ============================================================================
+
+void dimmer_key_cluster_add_to_endpoint(zigbee_dimmer_key_cluster *cluster,
+                                        hal_zigbee_endpoint *endpoint) {
+    dimmer_key_cluster_by_endpoint[endpoint->endpoint] = cluster;
+    cluster->endpoint      = endpoint->endpoint;
+    cluster->level_move_rate = 50;
+    cluster->present_value   = MULTISTATE_RELEASED;
+
+    dimmer_key_cluster_load_attrs_from_nv(cluster);
+
+    cluster->up_button->on_press =
+        (ev_button_callback_t)dimmer_key_cluster_on_up_press;
+    cluster->up_button->on_release =
+        (ev_button_callback_t)dimmer_key_cluster_on_up_release;
+    cluster->up_button->on_long_press =
+        (ev_button_callback_t)dimmer_key_cluster_on_up_long_press;
+    cluster->up_button->callback_param = cluster;
+
+    cluster->down_button->on_press =
+        (ev_button_callback_t)dimmer_key_cluster_on_down_press;
+    cluster->down_button->on_release =
+        (ev_button_callback_t)dimmer_key_cluster_on_down_release;
+    cluster->down_button->on_long_press =
+        (ev_button_callback_t)dimmer_key_cluster_on_down_long_press;
+    cluster->down_button->callback_param = cluster;
+
+    // Configuration attributes (manufacturer-specific server cluster)
+    SETUP_ATTR_FOR_TABLE(cluster->config_attr_infos, 0,
+                         ZCL_ATTR_DIMMER_KEY_CONFIG_LONG_PRESS_DUR,
+                         ZCL_DATA_TYPE_UINT16, ATTR_WRITABLE,
+                         cluster->up_button->long_press_duration_ms);
+    SETUP_ATTR_FOR_TABLE(cluster->config_attr_infos, 1,
+                         ZCL_ATTR_DIMMER_KEY_CONFIG_LEVEL_MOVE_RATE,
+                         ZCL_DATA_TYPE_UINT8, ATTR_WRITABLE,
+                         cluster->level_move_rate);
+
+    endpoint->clusters[endpoint->cluster_count].cluster_id      = ZCL_CLUSTER_DIMMER_KEY_CONFIG;
+    endpoint->clusters[endpoint->cluster_count].attribute_count = 2;
+    endpoint->clusters[endpoint->cluster_count].attributes      = cluster->config_attr_infos;
+    endpoint->clusters[endpoint->cluster_count].is_server       = 1;
+    endpoint->cluster_count++;
+
+    // OnOff client — for binding to lights
+    endpoint->clusters[endpoint->cluster_count].cluster_id      = ZCL_CLUSTER_ON_OFF;
+    endpoint->clusters[endpoint->cluster_count].attribute_count = 0;
+    endpoint->clusters[endpoint->cluster_count].attributes      = NULL;
+    endpoint->clusters[endpoint->cluster_count].is_server       = 0;
+    endpoint->cluster_count++;
+
+    // LevelControl client — for binding to dimmers
+    endpoint->clusters[endpoint->cluster_count].cluster_id      = ZCL_CLUSTER_LEVEL_CONTROL;
+    endpoint->clusters[endpoint->cluster_count].attribute_count = 0;
+    endpoint->clusters[endpoint->cluster_count].attributes      = NULL;
+    endpoint->clusters[endpoint->cluster_count].is_server       = 0;
+    endpoint->cluster_count++;
+
+    // MultistateInput — press action reporting
+    SETUP_ATTR_FOR_TABLE(cluster->multistate_attr_infos, 0,
+                         ZCL_ATTR_MULTISTATE_INPUT_NUMBER_OF_STATES,
+                         ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                         multistate_num_of_states);
+    SETUP_ATTR_FOR_TABLE(cluster->multistate_attr_infos, 1,
+                         ZCL_ATTR_MULTISTATE_INPUT_OUT_OF_SERVICE,
+                         ZCL_DATA_TYPE_BOOLEAN, ATTR_READONLY,
+                         multistate_out_of_service);
+    SETUP_ATTR_FOR_TABLE(cluster->multistate_attr_infos, 2,
+                         ZCL_ATTR_MULTISTATE_INPUT_PRESENT_VALUE,
+                         ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                         cluster->present_value);
+    SETUP_ATTR_FOR_TABLE(cluster->multistate_attr_infos, 3,
+                         ZCL_ATTR_MULTISTATE_INPUT_STATUS_FLAGS,
+                         ZCL_DATA_TYPE_BITMAP8, ATTR_READONLY,
+                         multistate_flags);
+
+    endpoint->clusters[endpoint->cluster_count].cluster_id      = ZCL_CLUSTER_MULTISTATE_INPUT_BASIC;
+    endpoint->clusters[endpoint->cluster_count].attribute_count = 4;
+    endpoint->clusters[endpoint->cluster_count].attributes      = cluster->multistate_attr_infos;
+    endpoint->clusters[endpoint->cluster_count].is_server       = 1;
+    endpoint->cluster_count++;
+}

--- a/src/zigbee/dimmer_key_cluster.c
+++ b/src/zigbee/dimmer_key_cluster.c
@@ -11,11 +11,11 @@
 // Constants
 // ============================================================================
 
-#define MULTISTATE_RELEASED     0
-#define MULTISTATE_UP_PRESS     1
-#define MULTISTATE_DOWN_PRESS   2
-#define MULTISTATE_UP_LONG      3
-#define MULTISTATE_DOWN_LONG    4
+#define MULTISTATE_RELEASED      0
+#define MULTISTATE_UP_PRESS      1
+#define MULTISTATE_DOWN_PRESS    2
+#define MULTISTATE_UP_LONG       3
+#define MULTISTATE_DOWN_LONG     4
 
 static const uint8_t  multistate_out_of_service = 0;
 static const uint8_t  multistate_flags          = 0;
@@ -50,7 +50,7 @@ static void dimmer_key_cluster_load_attrs_from_nv(zigbee_dimmer_key_cluster *clu
 
     cluster->up_button->long_press_duration_ms   = nv_config_buffer.button_long_press_duration;
     cluster->down_button->long_press_duration_ms = nv_config_buffer.button_long_press_duration;
-    cluster->level_move_rate                     = nv_config_buffer.level_move_rate;
+    cluster->level_move_rate = nv_config_buffer.level_move_rate;
 }
 
 // ============================================================================
@@ -157,7 +157,7 @@ static void dimmer_key_cluster_on_down_release(zigbee_dimmer_key_cluster *cluste
 void dimmer_key_cluster_add_to_endpoint(zigbee_dimmer_key_cluster *cluster,
                                         hal_zigbee_endpoint *endpoint) {
     dimmer_key_cluster_by_endpoint[endpoint->endpoint] = cluster;
-    cluster->endpoint      = endpoint->endpoint;
+    cluster->endpoint        = endpoint->endpoint;
     cluster->level_move_rate = 50;
     cluster->present_value   = MULTISTATE_RELEASED;
 
@@ -227,7 +227,8 @@ void dimmer_key_cluster_add_to_endpoint(zigbee_dimmer_key_cluster *cluster,
                          ZCL_DATA_TYPE_BITMAP8, ATTR_READONLY,
                          multistate_flags);
 
-    endpoint->clusters[endpoint->cluster_count].cluster_id      = ZCL_CLUSTER_MULTISTATE_INPUT_BASIC;
+    endpoint->clusters[endpoint->cluster_count].cluster_id =
+        ZCL_CLUSTER_MULTISTATE_INPUT_BASIC;
     endpoint->clusters[endpoint->cluster_count].attribute_count = 4;
     endpoint->clusters[endpoint->cluster_count].attributes      = cluster->multistate_attr_infos;
     endpoint->clusters[endpoint->cluster_count].is_server       = 1;

--- a/src/zigbee/dimmer_key_cluster.h
+++ b/src/zigbee/dimmer_key_cluster.h
@@ -12,10 +12,10 @@ typedef struct {
 
 typedef struct {
     // Parameters
-    uint8_t    dimmer_key_idx;
-    uint8_t    endpoint;
-    button_t * up_button;
-    button_t * down_button;
+    uint8_t              dimmer_key_idx;
+    uint8_t              endpoint;
+    button_t *           up_button;
+    button_t *           down_button;
 
     // Attributes
     uint8_t              level_move_rate;

--- a/src/zigbee/dimmer_key_cluster.h
+++ b/src/zigbee/dimmer_key_cluster.h
@@ -1,0 +1,34 @@
+#ifndef _DIMMER_KEY_CLUSTER_H_
+#define _DIMMER_KEY_CLUSTER_H_
+
+#include "base_components/button.h"
+#include "hal/zigbee.h"
+#include <stdint.h>
+
+typedef struct {
+    uint16_t button_long_press_duration;
+    uint8_t  level_move_rate;
+} zigbee_dimmer_key_cluster_config;
+
+typedef struct {
+    // Parameters
+    uint8_t    dimmer_key_idx;
+    uint8_t    endpoint;
+    button_t * up_button;
+    button_t * down_button;
+
+    // Attributes
+    uint8_t              level_move_rate;
+    hal_zigbee_attribute config_attr_infos[2];
+
+    uint16_t             present_value;
+    hal_zigbee_attribute multistate_attr_infos[4];
+} zigbee_dimmer_key_cluster;
+
+void dimmer_key_cluster_add_to_endpoint(zigbee_dimmer_key_cluster *cluster,
+                                        hal_zigbee_endpoint *endpoint);
+
+void dimmer_key_cluster_callback_attr_write_trampoline(uint8_t endpoint,
+                                                       uint16_t attribute_id);
+
+#endif

--- a/src/zigbee/general_commands.c
+++ b/src/zigbee/general_commands.c
@@ -2,6 +2,7 @@
 #include "consts.h"
 #include "cover_cluster.h"
 #include "cover_switch_cluster.h"
+#include "dimmer_key_cluster.h"
 #include "hal/printf_selector.h"
 #include "poll_control_cluster.h"
 #include "relay_cluster.h"
@@ -17,6 +18,8 @@ static void zigbee_on_attr_change(uint8_t endpoint, uint16_t cluster_id,
         switch_cluster_callback_attr_write_trampoline(endpoint, attribute_id);
     } else if (cluster_id == ZCL_CLUSTER_COVER_SWITCH_CONFIG) {
         cover_switch_cluster_callback_attr_write_trampoline(endpoint, attribute_id);
+    } else if (cluster_id == ZCL_CLUSTER_DIMMER_KEY_CONFIG) {
+        dimmer_key_cluster_callback_attr_write_trampoline(endpoint, attribute_id);
     } else if (cluster_id == ZCL_CLUSTER_ON_OFF) {
         relay_cluster_callback_attr_write_trampoline(endpoint, attribute_id);
     } else if (cluster_id == ZCL_CLUSTER_WINDOW_COVERING) {


### PR DESCRIPTION
Introduces a new Zigbee endpoint type for a two-button dimmer key (up/down), intended for controlling dimmable lights via bindings.
Added `K` entry type that parses up/down GPIO pins, initializes two buttons, and registers the dimmer key cluster on a new endpoint.
Added `ZCL_CLUSTER_DIMMER_KEY_CONFIG` (0xFC02) and its two attributes: `LONG_PRESS_DUR` and `LEVEL_MOVE_RATE`.