### PR TITLE
Add MakeGood MG-GPO01 (Sold as Melery)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -3004,7 +3004,7 @@ OUTLET_BSEED_TS011F:
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/145
   store: https://www.aliexpress.com/item/1005004402438527.html
 OUTLET_MAKEGOOD_MG_GPO01:
-  human_name: MakeGood MG-GPO01 double GPO
+  human_name: MakeGood MG-GPO01 double socket
   category: outlet
   power: mains
   neutral: required
@@ -3029,7 +3029,7 @@ OUTLET_MAKEGOOD_MG_GPO01:
   status: in_progress
   info: "2-gang outlet. Power monitoring not implemented. UART flash required — OTA leaves NV state breaking state reporting."
   threads: null
-  store: null
+  store: https://www.aliexpress.com/item/1005007951942511.html
 OUTLET_MOES_PM_TS011F:
   human_name: Moes PM wall socket
   category: outlet

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -3003,6 +3003,33 @@ OUTLET_BSEED_TS011F:
   info: Supported
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/145
   store: https://www.aliexpress.com/item/1005004402438527.html
+OUTLET_MAKEGOOD_MG_GPO01:
+  human_name: MakeGood MG-GPO01 double GPO
+  category: outlet
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS011F
+  stock_manufacturer_name: _TZ3210_bep7ccew
+  stock_converter_manufacturer: MakeGood
+  stock_converter_model: MG-GPO01
+  override_z2m_device: null
+  tuya_module: ZT3L
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: bep7ccew;TS011F-MG;LB4;SC3u;RD7;IC4;SD4u;RD2;IC0;M;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47009
+  build: yes
+  status: in_progress
+  info: "2-gang outlet. UART flash required — OTA leaves NV state breaking state reporting. Confirmed across 6 units."
+  threads: null
+  store: null
 OUTLET_MOES_PM_TS011F:
   human_name: Moes PM wall socket
   category: outlet

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -3003,7 +3003,7 @@ OUTLET_BSEED_TS011F:
   info: Supported
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/145
   store: https://www.aliexpress.com/item/1005004402438527.html
-OUTLET_MAKEGOOD_MG_GPO01:
+OUTLET_MAKEGOOD_PM_TS011F_2GANG:
   human_name: MakeGood MG-GPO01 double socket
   category: outlet
   power: mains
@@ -3027,8 +3027,8 @@ OUTLET_MAKEGOOD_MG_GPO01:
   firmware_image_type: 47009
   build: yes
   status: in_progress
-  info: "2-gang outlet. Power monitoring not implemented. UART flash required — OTA leaves NV state breaking state reporting."
-  threads: null
+  info: Power monitoring not implemented
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/440
   store: https://www.aliexpress.com/item/1005007951942511.html
 OUTLET_MOES_PM_TS011F:
   human_name: Moes PM wall socket

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -3027,7 +3027,7 @@ OUTLET_MAKEGOOD_MG_GPO01:
   firmware_image_type: 47009
   build: yes
   status: in_progress
-  info: "2-gang outlet. UART flash required — OTA leaves NV state breaking state reporting. Confirmed across 6 units."
+  info: "2-gang outlet. Power monitoring not implemented. UART flash required — OTA leaves NV state breaking state reporting."
   threads: null
   store: null
 OUTLET_MOES_PM_TS011F:


### PR DESCRIPTION
## MakeGood MG-GPO01 — UK double socket (2-gang, TS011F)

**Module:** ZT3L (Telink TLSR8258)  
**Stock Zigbee manufacturer:** `_TZ3210_bep7ccew`

### Pinout (confirmed via hardware testing)

| Pin | Function |
|-----|----------|
| B4  | Network LED (both blue LEDs) |
| C3  | Left touch button, pull-up |
| D7  | Left relay |
| C4  | Left indicator LED |
| D4  | Right touch button, pull-up |
| D2  | Right relay |
| C0  | Right indicator LED |

Both relays are independently controllable. Power monitoring is **not implemented**.

### Important: UART flash required

OTA flashing (including `-forced.zigbee`) leaves Tuya NV storage intact. This causes `genOnOff` attribute reporting to fail — the relay operates but state changes are not reported to Z2M, breaking toggle behaviour. A full erase + UART flash is required for correct operation.

Flash command (SWS via UART bridge):
```bash
python TLSR825xComFlasher.py --tact 10 -b 1500000 -p COM<n> ea wf 0 <firmware.bin>