### PR TITLE
Fix ZHA quirk: cap indicator loop to relays with LEDs

### DIFF
--- a/docs/changelog_fw.md
+++ b/docs/changelog_fw.md
@@ -50,6 +50,7 @@ Please describe what you are working on, under ## Upcoming
   - AC noise affecting Telink GPIO
   - Changing device type breaks Silabs NVM data
   - Reset needed 11 presses instead of 10
+  - ZHA quirk silently failed to apply on relay-less devices with LED indicators (scene remotes), leaving firmware attributes unreachable from the UI
 - **New**
   - SONOFF ZBMINIL2 version updates broken?
 

--- a/helper_scripts/templates/zha_quirk.py.jinja
+++ b/helper_scripts/templates/zha_quirk.py.jinja
@@ -345,7 +345,7 @@ for config in CONFIGS:
                 attribute_converter = lambda x: {0: "released", 1: "press", 2: "long_press", 3: "position_on", 4: "position_off"}[int(x)]
             )
         )
-    for endpoint_id in range(switch_cnt + 1, switch_cnt + indicators_cnt + 1):
+    for endpoint_id in range(switch_cnt + 1, switch_cnt + min(relay_cnt, indicators_cnt) + 1):
         builder = (
             builder
             .removes(OnOff.cluster_id, cluster_type=ClusterType.Client, endpoint_id=endpoint_id)


### PR DESCRIPTION
`helper_scripts/templates/zha_quirk.py.jinja:348` iterates over `range(switch_cnt + 1, switch_cnt + indicators_cnt + 1)` to apply indicator-related modifications to relay endpoints. The upper bound `indicators_cnt` is the count of `I*` peripherals from `config_str`, which **can exceed the number of relay endpoints** — for example on scene remotes (TS0041-TS0044, TS004F, etc.), where buttons have LEDs but there are no relays at all.

On those devices the loop steps past the relay range into endpoint IDs the device doesn't actually declare. `QuirkBuilder` resolves modifications via `device.endpoints[endpoint_id]` which raises `KeyError` → `CustomDeviceV2.__init__` aborts → quirk silently fails to apply → ZHA falls back to the default Tuya device handler, leaving the firmware's custom attributes unreachable from the UI.

Affected configs in current `device_db.yaml`: 20 relay-less remotes (HOBEIAN, IHSENO, LIDL, MOES, Tuya, generic TLSR82xx variants).

## Fix

Cap the loop's upper bound at `min(relay_cnt, indicators_cnt)`. On relay-less devices this collapses to `0`, the range is empty, and the loop is a no-op — quirk applies normally. On wired switches with `indicators_cnt == relay_cnt` (the typical case), behavior is unchanged.

## Scope

Template-only change. `zha/switch_quirk.py` is left to the next regen pass.
