### PR TITLE
Add 2CH & 3CH Mini Smart Switch (_TZ3000_n1j44rth, _TZ3000_uwhjgngj)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -1941,6 +1941,60 @@ MODULE_TLED_TS0001:
   info: Supported
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/225
   store: https://www.t-led.cz/p/smart-zigbee-3-0-spinac-zb2-68506
+MODULE_TUYA_A_TS0002:
+  human_name: Tuya 2-gang
+  category: module
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0002
+  stock_manufacturer_name: _TZ3000_n1j44rth
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0002
+  override_z2m_device: null
+  tuya_module: ZT2S_real
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: n1j44rth;TS0002-N1J44RTH;BB4u;LD2i;SC2u;RC4;SC3u;RB5;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47112
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/448
+  store: https://aliexpress.com/item/1005009640676478.html
+MODULE_TUYA_A_TS0003:
+  human_name: Tuya 3-gang
+  category: module
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0003
+  stock_manufacturer_name: _TZ3000_uwhjgngj
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0003
+  override_z2m_device: null
+  tuya_module: ZT2S_real
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: uwhjgngj;TS0003-UWHJGNGJ;BB1u;LB7i;SC2u;RB4;SC3u;RB5;SD2u;RC4;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47113
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/448
+  store: https://aliexpress.com/item/1005009640676478.html
 MODULE_TUYA_COMMON_TS0001:
   human_name: Tuya common 1-gang
   category: module
@@ -6085,57 +6139,3 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   info: Needs pinout. Secondary MCU. 6-gang!
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
-MODULE_TUYA_A_TS0002:
-  human_name: Tuya 2-gang
-  category: module
-  power: mains
-  neutral: required
-  output: relay
-  device_type: router
-  stock_model_name: TS0002
-  stock_manufacturer_name: _TZ3000_n1j44rth
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0002
-  override_z2m_device: null
-  tuya_module: ZT2S_real
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: n1j44rth;TS0002-N1J44RTH;BB4u;LD2i;SC2u;RC4;SC3u;RB5;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 54179
-  firmware_image_type: 47112
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/448
-  store: https://aliexpress.com/item/1005009640676478.html
-MODULE_TUYA_A_TS0003:
-  human_name: Tuya 3-gang
-  category: module
-  power: mains
-  neutral: required
-  output: relay
-  device_type: router
-  stock_model_name: TS0003
-  stock_manufacturer_name: _TZ3000_uwhjgngj
-  stock_converter_manufacturer: Tuya
-  stock_converter_model: TS0003
-  override_z2m_device: null
-  tuya_module: ZT2S_real
-  mcu_family: Telink
-  mcu: TLSR8258
-  config_str: uwhjgngj;TS0003-UWHJGNGJ;BB1u;LB7i;SC2u;RB4;SC3u;RB5;SD2u;RC4;
-  alt_config_str: null
-  old_manufacturer_names: null
-  old_zb_models: null
-  stock_manufacturer_id: 4417
-  stock_image_type: 54179
-  firmware_image_type: 47113
-  build: yes
-  status: fully_supported
-  info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/448
-  store: https://aliexpress.com/item/1005009640676478.html

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -6085,4 +6085,57 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   info: Needs pinout. Secondary MCU. 6-gang!
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
-
+MODULE_TUYA_MINI_TS0002:
+  human_name: Tuya 2CH Mini Smart Switch
+  category: module
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0002
+  stock_manufacturer_name: _TZ3000_n1j44rth
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0002
+  override_z2m_device: TS0002_basic_2
+  tuya_module: ZT2S_real
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: n1j44rth;TS0002-N1J44RTH;BB4u;LD2i;SC2u;RC4;SC3u;RB5;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47112
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: null
+  store: https://aliexpress.com/item/1005009640676478.html
+MODULE_TUYA_MINI_TS0003:
+  human_name: Tuya 3CH Mini Smart Switch
+  category: module
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0003
+  stock_manufacturer_name: _TZ3000_uwhjgngj
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0003
+  override_z2m_device: TS0003_switch_module_1
+  tuya_module: ZT2S_real
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: uwhjgngj;TS0003-UWHJGNGJ;BB1u;LB7i;SC2u;RB4;SC3u;RB5;SD2u;RC4;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 47113
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: null
+  store: https://aliexpress.com/item/1005009640676478.html

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -6085,8 +6085,8 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   info: Needs pinout. Secondary MCU. 6-gang!
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
-MODULE_TUYA_MINI_TS0002:
-  human_name: Tuya 2CH Mini Smart Switch
+MODULE_TUYA_A_TS0002:
+  human_name: Tuya 2-gang
   category: module
   power: mains
   neutral: required
@@ -6096,7 +6096,7 @@ MODULE_TUYA_MINI_TS0002:
   stock_manufacturer_name: _TZ3000_n1j44rth
   stock_converter_manufacturer: Tuya
   stock_converter_model: TS0002
-  override_z2m_device: TS0002_basic_2
+  override_z2m_device: null
   tuya_module: ZT2S_real
   mcu_family: Telink
   mcu: TLSR8258
@@ -6110,10 +6110,10 @@ MODULE_TUYA_MINI_TS0002:
   build: yes
   status: fully_supported
   info: Supported
-  threads: null
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/448
   store: https://aliexpress.com/item/1005009640676478.html
-MODULE_TUYA_MINI_TS0003:
-  human_name: Tuya 3CH Mini Smart Switch
+MODULE_TUYA_A_TS0003:
+  human_name: Tuya 3-gang
   category: module
   power: mains
   neutral: required
@@ -6123,7 +6123,7 @@ MODULE_TUYA_MINI_TS0003:
   stock_manufacturer_name: _TZ3000_uwhjgngj
   stock_converter_manufacturer: Tuya
   stock_converter_model: TS0003
-  override_z2m_device: TS0003_switch_module_1
+  override_z2m_device: null
   tuya_module: ZT2S_real
   mcu_family: Telink
   mcu: TLSR8258
@@ -6137,5 +6137,5 @@ MODULE_TUYA_MINI_TS0003:
   build: yes
   status: fully_supported
   info: Supported
-  threads: null
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/448
   store: https://aliexpress.com/item/1005009640676478.html


### PR DESCRIPTION
Adds `device_db.yaml` entries for two 2CH/3CH Mini Smart Switch modules:

- `_TZ3000_n1j44rth`
- `_TZ3000_uwhjgngj`

Both devices use Telink TLSR8258 MCUs, are mains-powered, require neutral, and use the Z2TS Telink board design. Their pinouts were verified on real hardware, which is currently in daily use with OTA-flashed custom firmware.

My units had black PCBs, but the layout appears to match the hardware shown here:

https://github.com/romasku/tuya-zigbee-switch/issues/400

### Added devices
 `_TZ3000_n1j44rth`
manufacturerName: _TZ3000_n1j44rth
model: TS0002
human_name: 2CH Mini Smart Switch, 
config_str: n1j44rth;TS0002-N1J44RTH;BB4u;LD2i;SC2u;RC4;SC3u;RB5;

 `_TZ3000_uwhjgngj`
manufacturerName: _TZ3000_uwhjgngj
model: TS0003
human_name: 2CH Mini Smart Switch, 
config_str: uwhjgngj;TS0003-UWHJGNGJ;BB1u;LB7i;SC2u;RB4;SC3u;RB5;SD2u;RC4;

I also added model overrides with more similar device images.

OTA flashing was tested successfully, and the switches work correctly.


<img width="595" height="274" alt="shop_pic" src="https://github.com/user-attachments/assets/196bcb66-79b9-41ee-bb0d-e7577774a87f" />

<img width="1953" height="1788" alt="IMG_20260615_014814_381" src="https://github.com/user-attachments/assets/78e74285-f70b-4578-b2e2-21e15adf1b20" />
<img width="1794" height="1662" alt="IMG_20260615_014821_918" src="https://github.com/user-attachments/assets/d8fbaaec-d535-4d55-8d79-81c65620a58d" />
<img width="2216" height="2160" alt="IMG_20260615_210541_479" src="https://github.com/user-attachments/assets/a78d699a-3a85-46ae-b1d0-c625096ea6ff" />
<img width="3072" height="3104" alt="IMG_20260615_210632_616" src="https://github.com/user-attachments/assets/526e0880-ac94-4c18-99d9-8fa8147dcc4d" />
<img width="3072" height="2744" alt="IMG_20260615_210809_440 - Copy" src="https://github.com/user-attachments/assets/ce56e1e7-971d-4a28-9cb1-7cea7b4180a4" />

### Additional hardware notes

These notes may be useful for future hardware identification or debugging.

Most of these boards use normally-open power relays. 

<img width="674" height="175" alt="power_relay" src="https://github.com/user-attachments/assets/0fe30096-1f2d-4be6-a13a-703b0c8b4a75" />

The orange pins are disconnected by default. When current flows through the relay coil from the red pin to the yellow pin, the orange pins are shorted together.

<img width="733" height="341" alt="J3Y_S8050" src="https://github.com/user-attachments/assets/bee0521d-b4f2-4a04-ab2a-b100e65a5e99" />

One side of the relay coil is connected to V+ — 5 V in this case. The other side, marked in yellow, is connected to the collector of an NPN transistor (J3Y), marked in green. The transistor can pull this side of the coil to GND. The MCU pins control the transistor bases, marked in blue.

<img width="3072" height="2800" alt="IMG_20260615_210809_440_with_markings" src="https://github.com/user-attachments/assets/1f62e25f-8d4e-44a2-bbb1-66f14df1b67a" />

The logical path from the MCU R1 pin to the high-voltage output is marked with a white arrow. Pins for the other relays are marked with corresponding colors.


