### PR TITLE
Add inverted flag to network indicator LED

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -271,7 +271,7 @@ MODULE_AUBESS_TS0001:
   tuya_module: ZT2S_real
   mcu_family: Telink
   mcu: TLSR8258
-  config_str: 46t1rvdu;WHD02-Aubess;BC4u;LD2;SB4u;RB5;
+  config_str: 46t1rvdu;WHD02-Aubess;BC4u;LD2i;SB4u;RB5;
   alt_config_str: null
   old_manufacturer_names:
   - WHD02-Aubess


### PR DESCRIPTION
Hi, I noticed that when network indicator switch is off, the LED is actually lit. It should be inverted.