### PR TITLE
Add Interlock Mode

### DIFF
--- a/helper_scripts/make_homed_extension.py
+++ b/helper_scripts/make_homed_extension.py
@@ -101,6 +101,13 @@ if __name__ == "__main__":
             "multiPressResetCount": {"type": "number", "min": 0, "max": 255}
         }
 
+        if relay_cnt > 1:
+            basic_custom_attrs["interlockMode"] = {"type": "bool", "clusterId": 0x0000, "attributeId": 0xff03, "dataType": 0x10, "action": True}
+            basic_custom_attrs["interlockDelay"] = {"type": "value", "clusterId": 0x0000, "attributeId": 0xff04, "dataType": 0x21, "action": True}
+            basic_exposes.extend(["interlockMode", "interlockDelay"])
+            basic_options["interlockMode"] = {"type": "toggle"}
+            basic_options["interlockDelay"] = {"type": "number", "min": 0, "max": 5000}
+
         if has_dedicated_net_led:
             basic_custom_attrs["networkIndicator"] = {"type": "bool", "clusterId": 0x0000, "attributeId": 0xff01, "dataType": 0x10, "action": True}
             basic_exposes.append("networkIndicator")

--- a/helper_scripts/templates/switch_custom.js.jinja
+++ b/helper_scripts/templates/switch_custom.js.jinja
@@ -186,6 +186,29 @@ const romasku = {
             valueMax: 255,
             entityCategory: "config",
         }),
+    interlockMode: (name, endpointName) =>
+        binary({
+            name,
+            endpointName,
+            valueOn: ["ON", 1],
+            valueOff: ["OFF", 0],
+            cluster: "genBasic",
+            attribute: {ID: 0xff03, type: 0x10},  // Boolean
+            description: "Enable interlock mode for relays",
+            access: "ALL",
+            entityCategory: "config",
+        }),
+    interlockDelay: (name, endpointName) =>
+        numeric({
+            name,
+            endpointNames: [endpointName],
+            cluster: "genBasic",
+            attribute: { ID: 0xff04, type: 0x21 }, // uint16
+            description: "Delay in milliseconds between turning off a relay and turning on the next in interlock mode",
+            valueMin: 0,
+            valueMax: 5000,
+            entityCategory: "config",
+        }),
     deviceConfig: (name, endpointName) =>
         text({
             name,
@@ -418,6 +441,10 @@ const definitions = [
             {% set first_endpoint = device.switchNames[0] if device.switchNames else (device.relayNames[0] if device.relayNames else (device.coverSwitchNames[0] if device.coverSwitchNames else device.coverNames[0])) %}
             romasku.deviceConfig("device_config", "{{first_endpoint}}"),
             romasku.multiPressResetCount("multi_press_reset_count", "{{first_endpoint}}"),
+            {% if device.relayNames and device.relayNames | length > 1 %}
+            romasku.interlockMode("interlock_mode", "{{first_endpoint}}"),
+            romasku.interlockDelay("interlock_delay", "{{first_endpoint}}"),
+            {% endif %}
             {% if device.has_dedicated_net_led %}
             romasku.networkIndicator("network_led", "{{first_endpoint}}"),
             {% endif%}

--- a/helper_scripts/templates/zha_quirk.py.jinja
+++ b/helper_scripts/templates/zha_quirk.py.jinja
@@ -121,6 +121,20 @@ class CustomBasicCluster(CustomCluster, Basic):
             is_manufacturer_specific=False,
         )
 
+        interlock_mode = ZCLAttributeDef(
+            id=0xff03,
+            type=t.Bool,
+            access="rw",
+            is_manufacturer_specific=False,
+        )
+
+        interlock_delay = ZCLAttributeDef(
+            id=0xff04,
+            type=t.uint16_t,
+            access="rw",
+            is_manufacturer_specific=False,
+        )
+
 
 class RelayIndicatorMode(t.enum8):
     Same = 0x00
@@ -488,6 +502,30 @@ for config in CONFIGS:
             entity_type=EntityType.CONFIG,
         )
     )
+
+    if relay_cnt > 1:
+        builder = (
+            builder
+            .switch(
+                CustomBasicCluster.AttributeDefs.interlock_mode.name,
+                CustomBasicCluster.cluster_id,
+                translation_key="interlock_mode",
+                fallback_name="Interlock mode",
+                endpoint_id=1,
+                entity_type=EntityType.CONFIG,
+            )
+            .number(
+                CustomBasicCluster.AttributeDefs.interlock_delay.name,
+                CustomBasicCluster.cluster_id,
+                translation_key="interlock_delay",
+                fallback_name="Interlock delay",
+                min_value=0,
+                max_value=5000,
+                step=1,
+                endpoint_id=1,
+                entity_type=EntityType.CONFIG,
+            )
+        )
 
     if has_dedicated_net_led:
         builder = (

--- a/src/telink/hal/zigbee_zcl.c
+++ b/src/telink/hal/zigbee_zcl.c
@@ -26,6 +26,7 @@ static hal_zigbee_endpoint *hal_endpoints = NULL;
 static uint8_t hal_endpoints_cnt          = 0;
 static hal_attribute_change_callback_t attribute_change_callback = NULL;
 static hal_zcl_activity_callback_t     zcl_activity_callback     = NULL;
+static volatile bool in_zcl_callback = false;
 
 static cluster_registerFunc_t get_register_func_by_cluster_id(u16 cluster_id) {
     if (cluster_id == ZCL_CLUSTER_GEN_BASIC) {
@@ -70,22 +71,25 @@ static status_t cmd_callback(u8 endpoint, u16 clusterId, u8 cmdId,
     hal_zigbee_cluster *cluster = hal_zigbee_find_cluster(
         hal_endpoints, hal_endpoints_cnt, endpoint, clusterId);
 
+    status_t ret = ZCL_STA_SUCCESS;
     if (cluster && cluster->cmd_callback) {
+        in_zcl_callback = true;
         hal_zigbee_cmd_result_t status = cluster->cmd_callback(
             endpoint, clusterId, cmdId, cmdPayload, cmdPayloadLen);
+        in_zcl_callback = false;
         if (status == HAL_ZIGBEE_CMD_PROCESSED) {
-            return ZCL_STA_SUCCESS;
+            ret = ZCL_STA_SUCCESS;
         } else if (status == HAL_ZIGBEE_INVALID_VALUE) {
-            return ZCL_STA_INVALID_VALUE;
+            ret = ZCL_STA_INVALID_VALUE;
         } else if (status == HAL_ZIGBEE_MALFORMED_COMMAND) {
-            return ZCL_STA_MALFORMED_COMMAND;
+            ret = ZCL_STA_MALFORMED_COMMAND;
         } else if (status == HAL_ZIGBEE_ACTION_DENIED) {
-            return ZCL_STA_ACTION_DENIED;
+            ret = ZCL_STA_ACTION_DENIED;
         } else if (status == HAL_ZIGBEE_CMD_SKIPPED) {
-            return ZCL_STA_UNSUP_CLUSTER_COMMAND;
+            ret = ZCL_STA_UNSUP_CLUSTER_COMMAND;
         }
     }
-    return(ZCL_STA_SUCCESS);
+    return ret;
 }
 
 static zclIncoming_t *cmd_incoming_from_addr_info(zclIncomingAddrInfo_t *pAddrInfo) {
@@ -148,12 +152,14 @@ static void zcl_incoming_message_callback(zclIncoming_t *pInHdlrMsg) {
         if (attribute_change_callback == NULL) {
             return;
         }
+        in_zcl_callback = true;
         zclWriteCmd_t *writeCmd = (zclWriteCmd_t *)pInHdlrMsg->attrCmd;
         for (u8 i = 0; i < writeCmd->numAttr; i++) {
             attribute_change_callback(pInHdlrMsg->msg->indInfo.dst_ep,
                                       pInHdlrMsg->msg->indInfo.cluster_id,
                                       writeCmd->attrList[i].attrID);
         }
+        in_zcl_callback = false;
     }
 }
 
@@ -237,7 +243,9 @@ void telink_zigbee_hal_zcl_init(hal_zigbee_endpoint *endpoints,
 
 void hal_zigbee_notify_attribute_changed(uint8_t endpoint, uint16_t cluster_id,
                                          uint16_t attribute_id) {
-    report_handler(); // Trigger reporting if needed
+    if (!in_zcl_callback) {
+        report_handler(); // Trigger reporting if needed
+    }
 }
 
 hal_zigbee_status_t hal_zigbee_send_cmd_to_bindings(const hal_zigbee_cmd *cmd) {

--- a/src/zigbee/basic_cluster.c
+++ b/src/zigbee/basic_cluster.c
@@ -27,6 +27,7 @@ uint8_t powerSource = POWER_SOURCE_MAINS_1_PHASE; // 0x01 default
 const uint16_t cluster_revision = 0x01;
 DEF_STR(STRINGIFY_VALUE(VERSION_STR), swBuildId);
 extern network_indicator_t network_indicator;
+extern zigbee_basic_cluster basic_cluster;
 
 void basic_cluster_store_attrs_to_nv();
 void basic_cluster_load_attrs_from_nv();
@@ -86,14 +87,18 @@ void basic_cluster_add_to_endpoint(zigbee_basic_cluster *cluster,
                ATTR_WRITABLE, device_config_str);
     SETUP_ATTR(12, ZCL_ATTR_BASIC_MULTI_PRESS_RESET_COUNT, ZCL_DATA_TYPE_UINT8,
                ATTR_WRITABLE, g_multi_press_reset_count);
+    SETUP_ATTR(13, ZCL_ATTR_BASIC_INTERLOCK_MODE, ZCL_DATA_TYPE_BOOLEAN,
+               ATTR_WRITABLE, cluster->interlock_mode);
+    SETUP_ATTR(14, ZCL_ATTR_BASIC_INTERLOCK_DELAY, ZCL_DATA_TYPE_UINT16,
+               ATTR_WRITABLE, cluster->interlock_delay_ms);
     if (network_indicator.has_dedicated_led) {
-        SETUP_ATTR(13, ZCL_ATTR_BASIC_STATUS_LED_STATE, ZCL_DATA_TYPE_BOOLEAN,
+        SETUP_ATTR(15, ZCL_ATTR_BASIC_STATUS_LED_STATE, ZCL_DATA_TYPE_BOOLEAN,
                    ATTR_WRITABLE, network_indicator.manual_state_when_connected);
     }
 
     endpoint->clusters[endpoint->cluster_count].cluster_id      = ZCL_CLUSTER_BASIC;
     endpoint->clusters[endpoint->cluster_count].attribute_count =
-        network_indicator.has_dedicated_led ? 14 : 13;
+        network_indicator.has_dedicated_led ? 16 : 15;
     endpoint->clusters[endpoint->cluster_count].attributes = cluster->attr_infos;
     endpoint->clusters[endpoint->cluster_count].is_server  = 1;
     endpoint->cluster_count++;
@@ -108,6 +113,8 @@ void basic_cluster_add_to_endpoint(zigbee_basic_cluster *cluster,
 
 typedef struct {
     uint8_t network_led_on;
+    uint8_t interlock_mode;
+    uint16_t interlock_delay_ms;
 } zigbee_basic_cluster_config;
 
 static zigbee_basic_cluster_config nv_config_buffer;
@@ -115,6 +122,8 @@ static zigbee_basic_cluster_config nv_config_buffer;
 void basic_cluster_store_attrs_to_nv() {
     nv_config_buffer.network_led_on =
         network_indicator.manual_state_when_connected;
+    nv_config_buffer.interlock_mode = basic_cluster.interlock_mode;
+    nv_config_buffer.interlock_delay_ms = basic_cluster.interlock_delay_ms;
 
     hal_nvm_write(NV_ITEM_BASIC_CLUSTER_DATA, sizeof(zigbee_basic_cluster_config),
                   (uint8_t *)&nv_config_buffer);
@@ -126,8 +135,18 @@ void basic_cluster_load_attrs_from_nv() {
                                        (uint8_t *)&nv_config_buffer);
 
     if (st != HAL_NVM_SUCCESS) {
+        basic_cluster.interlock_mode = 0;
+        basic_cluster.interlock_delay_ms = 100;
         return;
     }
     network_indicator.manual_state_when_connected =
         nv_config_buffer.network_led_on;
+    basic_cluster.interlock_mode = nv_config_buffer.interlock_mode;
+    basic_cluster.interlock_delay_ms = nv_config_buffer.interlock_delay_ms;
+    
+    // In case NVM was blank (0xFF)
+    if (basic_cluster.interlock_delay_ms == 0xFFFF) {
+        basic_cluster.interlock_mode = 0;
+        basic_cluster.interlock_delay_ms = 100;
+    }
 }

--- a/src/zigbee/basic_cluster.h
+++ b/src/zigbee/basic_cluster.h
@@ -9,7 +9,9 @@ typedef struct {
     uint8_t              deviceEnable;
     char                 manuName[32];
     char                 modelId[32];
-    hal_zigbee_attribute attr_infos[14];
+    uint8_t              interlock_mode;
+    uint16_t             interlock_delay_ms;
+    hal_zigbee_attribute attr_infos[16];
 } zigbee_basic_cluster;
 
 void basic_cluster_add_to_endpoint(zigbee_basic_cluster *cluster,

--- a/src/zigbee/consts.h
+++ b/src/zigbee/consts.h
@@ -44,6 +44,8 @@
 #define ZCL_ATTR_BASIC_DEVICE_CONFIG              0xff00
 #define ZCL_ATTR_BASIC_STATUS_LED_STATE           0xff01
 #define ZCL_ATTR_BASIC_MULTI_PRESS_RESET_COUNT    0xff02
+#define ZCL_ATTR_BASIC_INTERLOCK_MODE             0xff03
+#define ZCL_ATTR_BASIC_INTERLOCK_DELAY            0xff04
 
 // Power Configuration cluster
 

--- a/src/zigbee/relay_cluster.c
+++ b/src/zigbee/relay_cluster.c
@@ -4,6 +4,10 @@
 #include "device_config/nvm_items.h"
 #include "hal/nvm.h"
 #include "hal/printf_selector.h"
+#include "basic_cluster.h"
+
+extern zigbee_basic_cluster basic_cluster;
+extern uint8_t relay_clusters_cnt;
 
 hal_zigbee_cmd_result_t relay_cluster_callback(zigbee_relay_cluster *cluster,
                                                uint8_t command_id,
@@ -57,6 +61,10 @@ void relay_cluster_add_to_endpoint(zigbee_relay_cluster *cluster,
     relay_cluster_by_endpoint[endpoint->endpoint] = cluster;
     cluster->endpoint = endpoint->endpoint;
     relay_cluster_load_attrs_from_nv(cluster);
+
+    cluster->delayed_on_task.arg = cluster;
+    hal_tasks_init(&cluster->delayed_on_task);
+    cluster->pending_on = 0;
 
     cluster->relay->callback_param = cluster;
     cluster->relay->on_change      = (relay_callback_t)relay_cluster_on_relay_change;
@@ -181,19 +189,65 @@ void sync_indicator_led(zigbee_relay_cluster *cluster) {
                                         ZCL_ATTR_ONOFF_INDICATOR_STATE);
 }
 
+static void relay_cluster_delayed_on_handler(zigbee_relay_cluster *cluster) {
+    cluster->pending_on = 0;
+    relay_on(cluster->relay);
+    sync_indicator_led(cluster);
+}
+
 void relay_cluster_on(zigbee_relay_cluster *cluster) {
+    if (cluster->pending_on) {
+        return;
+    }
+    hal_tasks_unschedule(&cluster->delayed_on_task);
+    cluster->pending_on = 0;
+
+    if (basic_cluster.interlock_mode && relay_clusters_cnt > 1) {
+        bool others_were_active = false;
+        for (int i = 0; i < 10; i++) {
+            if (relay_cluster_by_endpoint[i] != NULL && 
+                relay_cluster_by_endpoint[i] != cluster) {
+                
+                if (relay_cluster_by_endpoint[i]->relay->on || 
+                    relay_cluster_by_endpoint[i]->pending_on) {
+                    
+                    relay_cluster_off(relay_cluster_by_endpoint[i]);
+                    others_were_active = true;
+                }
+            }
+        }
+        
+        if (others_were_active && basic_cluster.interlock_delay_ms > 0) {
+            cluster->pending_on = 1;
+            cluster->delayed_on_task.handler = (task_handler_t)relay_cluster_delayed_on_handler;
+            hal_tasks_schedule(&cluster->delayed_on_task, basic_cluster.interlock_delay_ms);
+            return;
+        }
+    }
+
     relay_on(cluster->relay);
     sync_indicator_led(cluster);
 }
 
 void relay_cluster_off(zigbee_relay_cluster *cluster) {
+    hal_tasks_unschedule(&cluster->delayed_on_task);
+    if (cluster->pending_on) {
+        cluster->pending_on = 0;
+        uint8_t val = 0;
+        hal_zigbee_send_report_attr(cluster->endpoint, ZCL_CLUSTER_ON_OFF,
+                                    ZCL_ATTR_ONOFF, ZCL_DATA_TYPE_BOOLEAN,
+                                    &val, 1);
+    }
     relay_off(cluster->relay);
     sync_indicator_led(cluster);
 }
 
 void relay_cluster_toggle(zigbee_relay_cluster *cluster) {
-    relay_toggle(cluster->relay);
-    sync_indicator_led(cluster);
+    if (cluster->relay->on || cluster->pending_on) {
+        relay_cluster_off(cluster);
+    } else {
+        relay_cluster_on(cluster);
+    }
 }
 
 void relay_cluster_on_relay_change(zigbee_relay_cluster *cluster,

--- a/src/zigbee/relay_cluster.h
+++ b/src/zigbee/relay_cluster.h
@@ -16,6 +16,8 @@ typedef struct {
     relay_t *            relay;
     led_t *              indicator_led;
     uint8_t              indicator_state;
+    hal_task_t           delayed_on_task;
+    uint8_t              pending_on;
 } zigbee_relay_cluster;
 
 void relay_cluster_add_to_endpoint(zigbee_relay_cluster *cluster,

--- a/zha/switch_quirk.py
+++ b/zha/switch_quirk.py
@@ -121,6 +121,20 @@ class CustomBasicCluster(CustomCluster, Basic):
             is_manufacturer_specific=False,
         )
 
+        interlock_mode = ZCLAttributeDef(
+            id=0xff03,
+            type=t.Bool,
+            access="rw",
+            is_manufacturer_specific=False,
+        )
+
+        interlock_delay = ZCLAttributeDef(
+            id=0xff04,
+            type=t.uint16_t,
+            access="rw",
+            is_manufacturer_specific=False,
+        )
+
 
 class RelayIndicatorMode(t.enum8):
     Same = 0x00
@@ -239,10 +253,10 @@ CONFIGS = [
     "nuenzetq1;TS0002-SC;LC3i;SD7u;RD4;SC0u;RA0;M;",
     "TUYA;DEV-ZTU2;LD7;SA0u;RC1;IB6;M;",
     "vbfp8eyv;TS011F-TD;LC4i;SC1u;RD4;IB6i;M;",
-    "46t1rvdu;WHD02-Aubess;BC4u;LD2;SB4u;RB5;",
-    "46t1rvdu;WHD02-Aubess-ED;BC4u;LD2;SB4u;RB5;",
-    "WHD02-Aubess;WHD02-Aubess;BC4u;LD2;SB4u;RB5;",
-    "WHD02-Aubess;WHD02-Aubess-ED;BC4u;LD2;SB4u;RB5;",
+    "46t1rvdu;WHD02-Aubess;BC4u;LD2i;SB4u;RB5;",
+    "46t1rvdu;WHD02-Aubess-ED;BC4u;LD2i;SB4u;RB5;",
+    "WHD02-Aubess;WHD02-Aubess;BC4u;LD2i;SB4u;RB5;",
+    "WHD02-Aubess;WHD02-Aubess-ED;BC4u;LD2i;SB4u;RB5;",
     "lmlsduws;TS0002-AUB;BC4u;LB1;SC2u;RB7;SC3u;RB4;",
     "lvhy15ix;TS0003-AUB;BC4u;LB1;SC2u;RB7;SC3u;RB4;SD2u;RB5;",
     "mmkbptmx;TS0004-custom;BB6u;LB1;SC1u;RB7;SC2u;RB5;SC3u;RB4;SD2u;RC4;",
@@ -355,6 +369,8 @@ CONFIGS = [
     "c8wtsv3p;MS105-ZB-CUSTOM;BC2u;LD2i;SD3u;RD7;",
     "sonoff;ZBMINIL2-custom;BA0u;LC5i;SA6u;RA5A4;",
     "npzfdcof;TS0001-TLED;BD2u;LC3i;SB5u;RB4;",
+    "n1j44rth;TS0002-N1J44RTH;BB4u;LD2i;SC2u;RC4;SC3u;RB5;",
+    "uwhjgngj;TS0003-UWHJGNGJ;BB1u;LB7i;SC2u;RB4;SC3u;RB5;SD2u;RC4;",
     "rfexs4vs;TS0001-C;BA0u;LC0;SB4u;RC2;",
     "khmapq4n;TS0001-SB;BA0u;LC0;SB4u;RC2;",
     "zbfya6h0;TS0002-C;BA0u;LC0;SB4u;RC2;SB5u;RC3;",
@@ -802,6 +818,30 @@ for config in CONFIGS:
             entity_type=EntityType.CONFIG,
         )
     )
+
+    if relay_cnt > 1:
+        builder = (
+            builder
+            .switch(
+                CustomBasicCluster.AttributeDefs.interlock_mode.name,
+                CustomBasicCluster.cluster_id,
+                translation_key="interlock_mode",
+                fallback_name="Interlock mode",
+                endpoint_id=1,
+                entity_type=EntityType.CONFIG,
+            )
+            .number(
+                CustomBasicCluster.AttributeDefs.interlock_delay.name,
+                CustomBasicCluster.cluster_id,
+                translation_key="interlock_delay",
+                fallback_name="Interlock delay",
+                min_value=0,
+                max_value=5000,
+                step=1,
+                endpoint_id=1,
+                entity_type=EntityType.CONFIG,
+            )
+        )
 
     if has_dedicated_net_led:
         builder = (


### PR DESCRIPTION
# Description

This PR introduces an **Interlock Mode** (mutually exclusive switch mode) for multi-channel switches (devices with 2 or more relay channels). 

When active, it ensures only one relay channel is active at a time. If another channel is commanded to turn on, the previously active channel is turned off first, followed by a configurable delay (in milliseconds) before the requested channel is activated.

## Key Changes

### 1. Firmware Logic (`src/zigbee/relay_cluster.c`, `relay_cluster.h`)
* Implemented basic interlock checks inside `relay_cluster_on`.
* Added asynchronous task scheduling via `hal_tasks_schedule` to implement the delay without blocking the CPU.
* Added a `pending_on` state tracking variable to handle race conditions under rapid sequential toggling, canceling pending relay activations when a different channel is selected.
* Forced immediate `OFF` reports (`hal_zigbee_send_report_attr`) when a pending channel activation is canceled, keeping the controller's UI in sync with the hardware.
* Deferred ZCL `report_handler` execution outside of ZCL message processing callbacks to prevent report packet drops inside command handlers.

### 2. Zigbee Custom Attributes (`src/zigbee/consts.h`, `basic_cluster.c`, `basic_cluster.h`)
* Added `0xFF03` (`ZCL_ATTR_BASIC_INTERLOCK_MODE`) - Boolean.
* Added `0xFF04` (`ZCL_ATTR_BASIC_INTERLOCK_DELAY`) - Uint16 (in milliseconds).
* Enabled NVM persistence.

### 3. Integrations & Generators
* **Zigbee2MQTT:** Updated converter templates (`switch_custom.js.jinja`) to automatically expose `interlockMode` and `interlockDelay` on devices with 2+ relays.
* **ZHA:** Added ZHA quirk mapping support in `zha_quirk.py.jinja`.
* **HOMEd:** Extended `make_homed_extension.py`.