### PR TITLE
Add RETLUX RSH30x switches

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -5838,7 +5838,7 @@ SWITCH_RETLUX_RSH301:
   build: yes
   status: fully_supported
   info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/TBD
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/475
   store: https://www.alza.sk/retlux-rsh-301-smart-jednotlacidlovy-podomietkovy-vypinac-d13119843.htm
 SWITCH_RETLUX_RSH302:
   human_name: Retlux RSH302 2-gang switch
@@ -5865,7 +5865,7 @@ SWITCH_RETLUX_RSH302:
   build: yes
   status: fully_supported
   info: Supported
-  threads: https://github.com/romasku/tuya-zigbee-switch/pull/TBD
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/475
   store: https://www.alza.sk/retlux-rsh-302-smart-dvojtlacidlovy-podomietkovy-vypinac-d13119841.htm
 SWITCH_TUYA_A_TS0001:
   human_name: Tuya 1-gang switch

--- a/device_db.yaml
+++ b/device_db.yaml
@@ -5813,6 +5813,60 @@ SWITCH_PSMART_SL_TS0003:
   info: Backlight on A5
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/252
   store: https://psmart.pl/pl/p/PSMART-Przelacznik-3-obwody-C-RM-ZigBee-TUYA/2051
+SWITCH_RETLUX_RSH301:
+  human_name: Retlux RSH301 1-gang switch
+  category: switch
+  power: mains
+  neutral: optional
+  output: relay_latching
+  device_type: end_device
+  stock_model_name: TS0011
+  stock_manufacturer_name: _TZ3000_ns91oqaa
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0011
+  override_z2m_device: null
+  tuya_module: ZT3L
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: ns91oqaa;TS0011-RSH;SC3u;RC2D4;IB7;M;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 43645
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/TBD
+  store: https://www.alza.sk/retlux-rsh-301-smart-jednotlacidlovy-podomietkovy-vypinac-d13119843.htm
+SWITCH_RETLUX_RSH302:
+  human_name: Retlux RSH302 2-gang switch
+  category: switch
+  power: mains
+  neutral: optional
+  output: relay_latching
+  device_type: end_device
+  stock_model_name: TS0012
+  stock_manufacturer_name: _TZ3000_uprzndgg
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0012
+  override_z2m_device: null
+  tuya_module: ZT3L
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: uprzndgg;TS0012-RSH;SC3u;RC2D4;IB7;SD2u;RB5C4;ID7;M;
+  alt_config_str: null
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 43646
+  build: yes
+  status: fully_supported
+  info: Supported
+  threads: https://github.com/romasku/tuya-zigbee-switch/pull/TBD
+  store: https://www.alza.sk/retlux-rsh-302-smart-dvojtlacidlovy-podomietkovy-vypinac-d13119841.htm
 SWITCH_TUYA_A_TS0001:
   human_name: Tuya 1-gang switch
   category: switch


### PR DESCRIPTION
Adds some switches commonly available in Slovakia and the Czech republic.
_TZ3000_ns91oqaa = 1-gang variant
_TZ3000_uprzndgg = 2-gang variant

On the spritual journey to figure this out I ended up setting up a port of usb2swire to the Raspberry Pi Pico which can be found here: https://github.com/substanc3-dev/pico-usb2swire
Not sure how useful to people this will be but I think it's a pretty nice alternative, especially considering I struggled getting the UART ways to work well.