### PR TITLE
Fix uncrustify formatting in spiflash storage driver (lint is red on main)

### DIFF
--- a/src/silabs/spiflash_extension/spiflash/btl_storage_spiflash.c
+++ b/src/silabs/spiflash_extension/spiflash/btl_storage_spiflash.c
@@ -87,6 +87,7 @@ static bool isPlausibleJedec(uint8_t mfgId, uint16_t deviceId) {
     // 0x11..0x19 -> 128 KiB .. 32 MiB, covering every realistic SPI-NOR on these modules
     return (densityCode >= 0x11) && (densityCode <= 0x19);
 }
+
 #endif
 
 // Match a JEDEC (manufacturer, device) id against the table of explicitly-supported

--- a/src/silabs/spiflash_extension/spiflash/btl_storage_spiflash_configs.h
+++ b/src/silabs/spiflash_extension/spiflash/btl_storage_spiflash_configs.h
@@ -162,7 +162,7 @@
 // Conservative full-part erase-time ceiling for the generic JEDEC fallback. Only
 // reported through getDeviceInfo(); erase completion is driven by the busy-status
 // poll, so an over-estimate here is harmless.
-#define TIMING_ERASE_GENERIC_MAX_MS            (245760)
+#define TIMING_ERASE_GENERIC_MAX_MS    (245760)
 
 /** @endcond */
 


### PR DESCRIPTION
The `lint` job has been failing on `main` since #457 was merged — see the `test` workflow runs for 13bc4d1 and every push since; 0c8bc30 and 44f74ed before it were green.

Two lines introduced by that PR (mine, sorry) don't match `uncrustify.cfg`:

- `btl_storage_spiflash_configs.h`: alignment of `#define TIMING_ERASE_GENERIC_MAX_MS`
- `btl_storage_spiflash.c`: missing blank line before `#endif`

Running `uncrustify` over `src/` locally, these were the only two failures out of 122 files, so this makes `lint` green again.

Note on reproducing: the CI image (ubuntu-24.04) ships **uncrustify 0.78.1**, and older versions disagree with it — 0.72 (Debian 12) reports failures on files that CI accepts, which is how I missed this in the first place. Worth pinning the version in the workflow if you want the check to be reproducible locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)