### PR TITLE
Add Tuya YNTDQ 1-gang relay module (_TZ3000_olo5jhjk)

### DIFF
--- a/device_db.yaml
+++ b/device_db.yaml
@@ -6247,3 +6247,30 @@ SWITCH_ZEMISMART_TS0601_6GANG:
   info: Needs pinout. Secondary MCU. 6-gang!
   threads: https://github.com/romasku/tuya-zigbee-switch/issues/209
   store: https://www.zemismart.com/products/tb26-6
+MODULE_YNTDQ_TS0001:
+  human_name: Tuya YNTDQ 1-gang
+  category: module
+  power: mains
+  neutral: required
+  output: relay
+  device_type: router
+  stock_model_name: TS0001
+  stock_manufacturer_name: _TZ3000_olo5jhjk
+  stock_converter_manufacturer: Tuya
+  stock_converter_model: TS0001
+  override_z2m_device: null
+  tuya_module: ZT2S_real
+  mcu_family: Telink
+  mcu: TLSR8258
+  config_str: olo5jhjk;TS0001-YNTDQ;BB4u;LC4i;SB5u;RD2;SB4u;
+  alt_config_str: olo5jhjk;TS0001-YNTDQ;BB4u;LC4i;SB5u;RD2;
+  old_manufacturer_names: null
+  old_zb_models: null
+  stock_manufacturer_id: 4417
+  stock_image_type: 54179
+  firmware_image_type: 45700
+  build: yes
+  status: fully_supported
+  info: Supported. Board button on B4 doubles as a second switch (alt config = reset only)
+  threads: null
+  store: null

--- a/docs/changelog_fw.md
+++ b/docs/changelog_fw.md
@@ -15,6 +15,14 @@ Please describe what you are working on, under ## Upcoming
 - **Hommyn 2-gang L-only relay module** (`_TZ3000_0e6uvexf`, `MODULE_HOMMYN_TS0012`)
   - Pinout: L1 `RB5`, L2 `RB4`, switches `SC2f`/`SC3f`
   - Defaults to momentary switch mode (`M;` in config)
+- **Tuya YNTDQ 1-gang relay module** (`_TZ3000_olo5jhjk`, `MODULE_YNTDQ_TS0001`)
+  - ZT2S module (TLSR8258), board YNTDQ_Ver1.0, relay board TDQXB_Ver1.0, L+N
+  - Pinout: button `BB4u`, network LED `LC4i`, switch `SB5u`, relay `RD2`
+  - The board button on `B4` is declared both as reset (`BB4u`) and as a second
+    switch (`SB4u`), reproducing stock behaviour: short press toggles the relay,
+    long press still resets. Verified on hardware — the two handlers coexist.
+  - `alt_config_str` keeps the plain variant where `B4` is reset only
+  - Each pin verified on hardware after OTA from stock firmware
 
 ### Features
 


### PR DESCRIPTION
## Device

Tuya YNTDQ 1-gang relay module, `_TZ3000_olo5jhjk` / `TS0001`.

- Module: ZT2S (real), MCU TLSR8258
- Boards: YNTDQ_Ver1.0 + relay board TDQXB_Ver1.0
- Mains, neutral required. Terminals: L, N, L-OUT, N-OUT, S1, S2

## Pinout

`olo5jhjk;TS0001-YNTDQ;BB4u;LC4i;SB5u;RD2;SB4u;`

| Pin | Function | Verification |
|---|---|---|
| `RD2` | relay | lamp switched on `state_relay` command |
| `SB5u` | switch input | external momentary button toggles the relay |
| `LC4i` | network LED | found by sweeping candidates with blink series; inversion required |
| `B4` | board button | temporarily declared as `S`, produced 120 press/released events |

Not a Girier clone: only `R` and `S` match. Girier uses `BB1u;LC3i`,
this board uses `B4`/`C4`.

## Board button declared twice

`B4` is declared both as reset (`BB4u`) and as a second switch (`SB4u`).
This reproduces the stock behaviour — a short press toggles the relay, a long
press still resets the device. Verified on hardware: both handlers coexist on
the same GPIO without conflicts.

`alt_config_str` keeps the plain variant where `B4` is reset only, for anyone
who prefers the canonical single-switch layout.

## Testing

Flashed over the air and verified on real hardware.

Initially flashed using the existing `MODULE_GIRIER_TS0001` `-from_tuya` image
(same ZT2S module, same MCU, same 4417/54179 stock IDs) via a custom OTA index,
then determined the pinout live by rewriting `config_str` over MQTT.

Afterwards I built this entry on my fork and updated the device to its own
image (`imageType: 45700`, `1.1.2-ef1c4f38`), migrating from the Girier image
with the `i45700` config option. Verified that the config string baked into
the built binary matches this entry.

Confirmed working: relay, both switch inputs, network LED, momentary mode,
and the dual role of B4 (short press toggles the relay, long press resets).

Note: the failing `test` check is the uncrustify lint step, which also fails
on upstream `main` (e.g. bf1059ee) — unrelated to this change, no `src/` files
are touched here.