### PR TITLE
Add BL0937 energy metering: Electrical Measurement + Metering clusters

### DIFF
--- a/helper_scripts/make_z2m_custom_converters.py
+++ b/helper_scripts/make_z2m_custom_converters.py
@@ -45,9 +45,12 @@ if __name__ == "__main__":
         indicators_cnt = 0
         has_dedicated_net_led = False
         has_battery_cluster = False
+        has_metering = False
         for peripheral in peripherals:
             if peripheral == "SLP" or peripheral == "M":
                 continue
+            if peripheral[0] == "E":
+                has_metering = True
             if peripheral[0] == "R":
                 relay_cnt += 1
             if peripheral[0] == "S":
@@ -117,6 +120,7 @@ if __name__ == "__main__":
                 "coverNames": cover_names,
                 "has_dedicated_net_led": has_dedicated_net_led,
                 "has_battery_cluster": has_battery_cluster,
+                "has_metering": has_metering,
             }
         )
 

--- a/helper_scripts/templates/switch_custom.js.jinja
+++ b/helper_scripts/templates/switch_custom.js.jinja
@@ -6,6 +6,7 @@ const {
     text,
     binary,
     windowCovering,
+    electricityMeter,
     deviceAddCustomCluster,
 } = require("zigbee-herdsman-converters/lib/modernExtend");
 const {assertString} = require("zigbee-herdsman-converters/lib/utils");
@@ -237,12 +238,19 @@ const romasku = {
                         validatePin(part.slice(3,5));
                     } else if (part[0] == 'L' || part[0] == 'R' || part[0] == 'I') {
                         validatePin(part.slice(1,3));
+                    } else if (part[0] == 'E') {
+                        validatePin(part.slice(1,3));  // CF
+                        validatePin(part.slice(3,5));  // CF1
+                        validatePin(part.slice(5,7));  // SEL
+                        if (part.length > 7 && part[7] != 'i') {
+                            throw new Error(`SEL invert flag ${part[7]} is invalid. Use 'i' or omit`);
+                        }
                     } else if(part[0] == 'M') {
                         ;
                     } else if(part[0] == 'i') {
                         ; // TODO: write validation
                     } else {
-                        throw new Error(`Invalid entry ${part}. Should start with one of B, BT, C, D, I, L, M, R, S, SLP, X, i`);
+                        throw new Error(`Invalid entry ${part}. Should start with one of B, BT, C, D, E, I, L, M, R, S, SLP, X, i`);
                     }
                 }
             },
@@ -418,6 +426,9 @@ const definitions = [
             {% set first_endpoint = device.switchNames[0] if device.switchNames else (device.relayNames[0] if device.relayNames else (device.coverSwitchNames[0] if device.coverSwitchNames else device.coverNames[0])) %}
             romasku.deviceConfig("device_config", "{{first_endpoint}}"),
             romasku.multiPressResetCount("multi_press_reset_count", "{{first_endpoint}}"),
+            {% if device.has_metering %}
+            electricityMeter({ endpointNames: ["{{first_endpoint}}"] }),
+            {% endif %}
             {% if device.has_dedicated_net_led %}
             romasku.networkIndicator("network_led", "{{first_endpoint}}"),
             {% endif%}

--- a/src/base_components/metering_bl0937.c
+++ b/src/base_components/metering_bl0937.c
@@ -1,0 +1,138 @@
+#include "metering_bl0937.h"
+#include <stddef.h>
+
+#include "hal/printf_selector.h"
+#include "hal/timer.h"
+
+// Defaults approximating a common BL0937 plug (calibrate per board!)
+#define DEFAULT_INTERVAL_MS              2000
+#define DEFAULT_COEF_POWER_MHZ_PER_DW    122   // ~1.22 Hz per W
+#define DEFAULT_COEF_VOLTAGE_MHZ_PER_DV  62    // ~1.43 kHz at 230 V
+#define DEFAULT_COEF_CURRENT_MHZ_PER_MA  30    // ~30 Hz per A
+#define DEFAULT_PULSES_PER_WH            1000
+
+static void _metering_update_callback(void *arg);
+
+static uint32_t freq_mhz(uint32_t pulses, uint32_t elapsed_ms) {
+    if (elapsed_ms == 0) {
+        return 0;
+    }
+    // 32-bit only math: the TC32 toolchain does not provide 64-bit
+    // division helpers (__udivdi3). Split the *1e6 scaling in two
+    // *1000 steps, carrying the remainder for precision.
+    if (pulses > 4000000U) {
+        pulses = 4000000U; // clamp far above any real BL0937 rate
+    }
+    uint32_t k = pulses * 1000U;
+    uint32_t q = k / elapsed_ms;
+    uint32_t r = k % elapsed_ms;
+    return q * 1000U + (r * 1000U) / elapsed_ms;
+}
+
+int8_t metering_bl0937_init(metering_bl0937_t *m) {
+    if (m->interval_ms == 0) {
+        m->interval_ms = DEFAULT_INTERVAL_MS;
+    }
+    if (m->coef_power_mhz_per_dw == 0) {
+        m->coef_power_mhz_per_dw = DEFAULT_COEF_POWER_MHZ_PER_DW;
+    }
+    if (m->coef_voltage_mhz_per_dv == 0) {
+        m->coef_voltage_mhz_per_dv = DEFAULT_COEF_VOLTAGE_MHZ_PER_DV;
+    }
+    if (m->coef_current_mhz_per_ma == 0) {
+        m->coef_current_mhz_per_ma = DEFAULT_COEF_CURRENT_MHZ_PER_MA;
+    }
+    if (m->pulses_per_wh == 0) {
+        m->pulses_per_wh = DEFAULT_PULSES_PER_WH;
+    }
+
+    // BL0937 pulse outputs are push-pull; count falling edges, no pull.
+    m->cf_counter = hal_gpio_counter_init(m->cf_pin, HAL_GPIO_COUNTER_FALLING,
+                                          HAL_GPIO_PULL_NONE);
+    if (m->cf_counter == HAL_GPIO_COUNTER_INVALID) {
+        printf("metering: no counter available for CF\r\n");
+        return -1;
+    }
+    m->cf1_counter = hal_gpio_counter_init(m->cf1_pin, HAL_GPIO_COUNTER_FALLING,
+                                           HAL_GPIO_PULL_NONE);
+    if (m->cf1_counter == HAL_GPIO_COUNTER_INVALID) {
+        printf("metering: no counter available for CF1\r\n");
+        hal_gpio_counter_deinit(m->cf_counter);
+        m->cf_counter = HAL_GPIO_COUNTER_INVALID;
+        return -1;
+    }
+
+    // Start measuring current first
+    hal_gpio_init(m->sel_pin, 0, HAL_GPIO_PULL_NONE);
+    hal_gpio_write(m->sel_pin, m->sel_current_level);
+    m->sel_state = 1;
+
+    hal_gpio_counter_start(m->cf_counter);
+    hal_gpio_counter_start(m->cf1_counter);
+    m->last_sample_ms = hal_millis();
+
+    m->update_task.handler = _metering_update_callback;
+    m->update_task.arg     = m;
+    hal_tasks_init(&m->update_task);
+    hal_tasks_schedule(&m->update_task, m->interval_ms);
+
+    printf("metering: BL0937 driver started (interval %d ms)\r\n",
+           (int)m->interval_ms);
+    return 0;
+}
+
+void metering_bl0937_deinit(metering_bl0937_t *m) {
+    hal_tasks_unschedule(&m->update_task);
+    if (m->cf_counter != HAL_GPIO_COUNTER_INVALID) {
+        hal_gpio_counter_deinit(m->cf_counter);
+        m->cf_counter = HAL_GPIO_COUNTER_INVALID;
+    }
+    if (m->cf1_counter != HAL_GPIO_COUNTER_INVALID) {
+        hal_gpio_counter_deinit(m->cf1_counter);
+        m->cf1_counter = HAL_GPIO_COUNTER_INVALID;
+    }
+}
+
+static void _metering_update_callback(void *arg) {
+    metering_bl0937_t *m = (metering_bl0937_t *)arg;
+
+    uint32_t now     = hal_millis();
+    uint32_t elapsed = now - m->last_sample_ms;
+    m->last_sample_ms = now;
+
+    uint32_t cf_pulses  = hal_gpio_counter_read_and_reset(m->cf_counter);
+    uint32_t cf1_pulses = hal_gpio_counter_read_and_reset(m->cf1_counter);
+
+    // --- Active power + energy from CF ---
+    uint32_t p_mhz = freq_mhz(cf_pulses, elapsed);
+    uint32_t p_dw  = p_mhz / m->coef_power_mhz_per_dw;
+    m->power_dw = (p_dw > INT16_MAX) ? INT16_MAX : (int16_t)p_dw;
+
+    m->energy_pulses   += cf_pulses;
+    m->residual_pulses += cf_pulses;
+    while (m->residual_pulses >= m->pulses_per_wh) {
+        m->residual_pulses -= m->pulses_per_wh;
+        m->energy_wh++;
+    }
+
+    // --- Voltage or current from CF1, depending on the finished phase ---
+    uint32_t s_mhz = freq_mhz(cf1_pulses, elapsed);
+    if (m->sel_state) {
+        uint32_t i_ma = s_mhz / m->coef_current_mhz_per_ma;
+        m->current_ma = (i_ma > UINT16_MAX) ? UINT16_MAX : (uint16_t)i_ma;
+    } else {
+        uint32_t v_dv = s_mhz / m->coef_voltage_mhz_per_dv;
+        m->voltage_dv = (v_dv > UINT16_MAX) ? UINT16_MAX : (uint16_t)v_dv;
+    }
+
+    // Toggle SEL for the next phase
+    m->sel_state = !m->sel_state;
+    hal_gpio_write(m->sel_pin,
+                   m->sel_state ? m->sel_current_level : !m->sel_current_level);
+
+    if (m->on_update != NULL) {
+        m->on_update(m->callback_param);
+    }
+
+    hal_tasks_schedule(&m->update_task, m->interval_ms);
+}

--- a/src/base_components/metering_bl0937.h
+++ b/src/base_components/metering_bl0937.h
@@ -1,0 +1,78 @@
+#ifndef _METERING_BL0937_H_
+#define _METERING_BL0937_H_
+
+#include <stdint.h>
+
+#include "hal/gpio.h"
+#include "hal/tasks.h"
+
+/*
+ * BL0937 / HLW8012-family energy metering driver.
+ *
+ * The chip outputs pulses on two pins:
+ *   - CF:  pulse frequency proportional to active power. Pulses are also
+ *          accumulated for energy metering.
+ *   - CF1: pulse frequency proportional to either RMS current or RMS
+ *          voltage, selected with the SEL pin.
+ *
+ * The driver alternates SEL every `interval_ms`, reading the hardware
+ * pulse counters (see hal_gpio_counter_* API) at each phase boundary.
+ * The first CF1 interval after each SEL toggle belongs to the newly
+ * selected magnitude, so no sample is discarded; frequency is computed
+ * from the pulse count over the elapsed interval.
+ *
+ * Calibration: coefficients express pulse frequency in mHz per output
+ * unit. Defaults approximate a typical BL0937 plug (1 mOhm shunt,
+ * ~1:2000 voltage divider) and MUST be trimmed per board. See
+ * `docs/contribute/` notes in the PR for the calibration procedure.
+ */
+
+typedef void (*metering_callback_t)(void *param);
+
+typedef struct {
+    // Wiring (set before metering_bl0937_init)
+    hal_gpio_pin_t cf_pin;
+    hal_gpio_pin_t cf1_pin;
+    hal_gpio_pin_t sel_pin;
+    uint8_t        sel_current_level; // SEL level that routes CURRENT to CF1
+
+    // Behaviour
+    uint32_t interval_ms;             // per-phase sampling window (default 2000)
+
+    // Calibration (pulse frequency in mHz per engineering unit)
+    uint32_t coef_power_mhz_per_dw;   // mHz per deciwatt
+    uint32_t coef_voltage_mhz_per_dv; // mHz per decivolt
+    uint32_t coef_current_mhz_per_ma; // mHz per milliamp
+    uint32_t pulses_per_wh;           // CF pulses per accumulated Wh
+
+    // Outputs (engineering units, ZCL friendly)
+    uint16_t voltage_dv;              // RMS voltage, 0.1 V
+    uint16_t current_ma;              // RMS current, mA
+    int16_t  power_dw;                // active power, 0.1 W
+    uint64_t energy_pulses;           // lifetime CF pulses (energy source)
+    uint32_t energy_wh;               // derived accumulated energy, Wh
+
+    // Notification
+    metering_callback_t on_update;    // fired after each phase completes
+    void *              callback_param;
+
+    // Internal state
+    hal_gpio_counter_t cf_counter;
+    hal_gpio_counter_t cf1_counter;
+    uint8_t            sel_state;     // 1 while CF1 carries current
+    uint32_t           residual_pulses; // CF remainder for Wh conversion
+    uint32_t           last_sample_ms;
+    hal_task_t         update_task;
+} metering_bl0937_t;
+
+/**
+ * Initialize the metering driver. Pins and (optionally) calibration must
+ * be filled in beforehand; zeroed calibration fields get defaults.
+ * @return 0 on success, -1 if hardware counters are unavailable
+ */
+int8_t metering_bl0937_init(metering_bl0937_t *m);
+
+/** Stop sampling and release the hardware counters */
+void metering_bl0937_deinit(metering_bl0937_t *m);
+
+#endif

--- a/src/device_config/config_parser.c
+++ b/src/device_config/config_parser.c
@@ -10,6 +10,8 @@
 #include "zigbee/relay_cluster.h"
 #include "zigbee/poll_control_cluster.h"
 #include "zigbee/switch_cluster.h"
+#include "zigbee/metering_cluster.h"
+#include "zigbee/cover_cluster.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -52,6 +54,10 @@ zigbee_group_cluster group_cluster = {};
 
 zigbee_switch_cluster switch_clusters[4];
 uint8_t switch_clusters_cnt = 0;
+
+metering_bl0937_t       metering;
+zigbee_metering_cluster metering_cluster;
+uint8_t                 metering_enabled = 0;
 
 zigbee_relay_cluster relay_clusters[4];
 uint8_t relay_clusters_cnt = 0;
@@ -230,6 +236,15 @@ void parse_config() {
 
             relays_cnt++;
             relay_clusters_cnt++;
+        } else if (entry[0] == 'E') {
+            // Energy metering (BL0937): E<cf><cf1><sel>[i]
+            //   cf/cf1/sel: 2-char pin names; trailing 'i' inverts SEL
+            //   (current measured while SEL is LOW instead of HIGH)
+            metering.cf_pin            = hal_gpio_parse_pin(entry + 1);
+            metering.cf1_pin           = hal_gpio_parse_pin(entry + 3);
+            metering.sel_pin           = hal_gpio_parse_pin(entry + 5);
+            metering.sel_current_level = (entry[7] == 'i') ? 0 : 1;
+            metering_enabled           = 1;
         } else if (entry[0] == 'X') {
             hal_gpio_pin_t  open_pin  = hal_gpio_parse_pin(entry + 1);
             hal_gpio_pin_t  close_pin = hal_gpio_parse_pin(entry + 3);
@@ -260,6 +275,7 @@ void parse_config() {
                 cover_switch_clusters_cnt;
             cover_switch_clusters_cnt++;
         } else if (entry[0] == 'C') {
+
             hal_gpio_pin_t open_pin  = hal_gpio_parse_pin(entry + 1);
             hal_gpio_pin_t close_pin = hal_gpio_parse_pin(entry + 3);
 
@@ -330,6 +346,11 @@ void parse_config() {
 
     hal_ota_cluster_setup(&endpoints[0].clusters[endpoints[0].cluster_count]);
     endpoints[0].cluster_count++;
+
+    if (metering_enabled) {
+        metering_cluster.metering = &metering;
+        metering_cluster_add_to_endpoint(&metering_cluster, &endpoints[0]);
+    }
 
     // Add battery cluster for battery-powered devices
     if (battery.pin != HAL_INVALID_PIN) {
@@ -419,6 +440,11 @@ void peripherals_init() {
     }
     for (int index = 0; index < relays_cnt; index++) {
         relay_init(&relays[index]);
+    }
+    if (metering_enabled) {
+        if (metering_bl0937_init(&metering) != 0) {
+            metering_enabled = 0;
+        }
     }
     if (hal_zigbee_get_network_status() == HAL_ZIGBEE_NETWORK_JOINED) {
         network_indicator_connected(&network_indicator);

--- a/src/silabs/hal/gpio_counter.c
+++ b/src/silabs/hal/gpio_counter.c
@@ -1,0 +1,35 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "hal/gpio.h"
+#include <stdio.h>
+
+
+hal_gpio_counter_t hal_gpio_counter_init(hal_gpio_pin_t gpio_pin,
+                                         hal_gpio_counter_edge_t edge,
+                                         hal_gpio_pull_t pull) {
+    // No-op for now
+
+    return HAL_GPIO_COUNTER_INVALID;
+}
+
+void hal_gpio_counter_deinit(hal_gpio_counter_t counter) {
+    // No-op for now
+}
+
+uint32_t hal_gpio_counter_read(hal_gpio_counter_t counter) {
+    return 0;
+}
+
+void hal_gpio_counter_reset(hal_gpio_counter_t counter) {
+    // No-op for now
+}
+
+void hal_gpio_counter_start(hal_gpio_counter_t counter) {
+    // No-op for now
+}
+
+void hal_gpio_counter_stop(hal_gpio_counter_t counter) {
+    // No-op for now
+}

--- a/src/silabs/slcp_files/zigbee.slcp
+++ b/src/silabs/slcp_files/zigbee.slcp
@@ -12,12 +12,14 @@ source:
 - {path: ../../silabs/main.c}
 - {path: ../../silabs/hal/zigbee.c}
 - {path: ../../silabs/hal/gpio.c}
+- {path: ../../silabs/hal/gpio_counter.c}
 - {path: ../../silabs/hal/nvm.c}
 - {path: ../../silabs/hal/tasks.c}
 - {path: ../../silabs/hal/timer.c}
 - {path: ../../silabs/hal/system.c}
 - {path: ../../silabs/hal/adc.c}
 - {path: ../../silabs/hal/ota.c}
+- {path: ../../silabs/hal/flash.c}
 - {path: ../../silabs/hal/silabs_gpio_utils.h}
 - {path: ../../hal/adc.h}
 - {path: ../../hal/zigbee.h}
@@ -33,6 +35,8 @@ source:
 - {path: ../../base_components/led.c}
 - {path: ../../base_components/network_indicator.c}
 - {path: ../../base_components/relay.c}
+- {path: ../../base_components/metering_bl0937.c}
+- {path: ../../base_components/oem_scanner.c}
 - {path: ../../base_components/battery.h}
 - {path: ../../base_components/button.h}
 - {path: ../../base_components/led.h}
@@ -53,6 +57,7 @@ source:
 - {path: ../../zigbee/general_commands.c}
 - {path: ../../zigbee/group_cluster.c}
 - {path: ../../zigbee/relay_cluster.c}
+- {path: ../../zigbee/metering_cluster.c}
 - {path: ../../zigbee/switch_cluster.c}
 - {path: ../../zigbee/cover_switch_cluster.c}
 - {path: ../../zigbee/cover_cluster.c}

--- a/src/silabs/slcp_files/zigbee_end_device.slcp
+++ b/src/silabs/slcp_files/zigbee_end_device.slcp
@@ -12,12 +12,14 @@ source:
 - {path: ../../silabs/main.c}
 - {path: ../../silabs/hal/zigbee.c}
 - {path: ../../silabs/hal/gpio.c}
+- {path: ../../silabs/hal/gpio_counter.c}
 - {path: ../../silabs/hal/nvm.c}
 - {path: ../../silabs/hal/tasks.c}
 - {path: ../../silabs/hal/timer.c}
 - {path: ../../silabs/hal/system.c}
 - {path: ../../silabs/hal/adc.c}
 - {path: ../../silabs/hal/ota.c}
+- {path: ../../silabs/hal/flash.c}
 - {path: ../../silabs/hal/silabs_gpio_utils.h}
 - {path: ../../hal/adc.h}
 - {path: ../../hal/zigbee.h}
@@ -33,6 +35,8 @@ source:
 - {path: ../../base_components/led.c}
 - {path: ../../base_components/network_indicator.c}
 - {path: ../../base_components/relay.c}
+- {path: ../../base_components/metering_bl0937.c}
+- {path: ../../base_components/oem_scanner.c}
 - {path: ../../base_components/battery.h}
 - {path: ../../base_components/button.h}
 - {path: ../../base_components/led.h}
@@ -53,6 +57,7 @@ source:
 - {path: ../../zigbee/general_commands.c}
 - {path: ../../zigbee/group_cluster.c}
 - {path: ../../zigbee/relay_cluster.c}
+- {path: ../../zigbee/metering_cluster.c}
 - {path: ../../zigbee/switch_cluster.c}
 - {path: ../../zigbee/cover_switch_cluster.c}
 - {path: ../../zigbee/cover_cluster.c}

--- a/src/stub/Makefile
+++ b/src/stub/Makefile
@@ -49,6 +49,7 @@ SOURCES := \
 	$(SRC_DIR)/stub/machine_io.c \
 	$(SRC_DIR)/base_components/led.c \
 	$(SRC_DIR)/base_components/relay.c \
+	$(SRC_DIR)/base_components/metering_bl0937.c \
 	$(SRC_DIR)/base_components/button.c \
 	$(SRC_DIR)/base_components/battery.c \
 	$(SRC_DIR)/base_components/network_indicator.c \
@@ -59,6 +60,7 @@ SOURCES := \
 	$(SRC_DIR)/device_config/nvm_migrations.c \
 	$(SRC_DIR)/zigbee/basic_cluster.c \
 	$(SRC_DIR)/zigbee/relay_cluster.c \
+	$(SRC_DIR)/zigbee/metering_cluster.c \
 	$(SRC_DIR)/zigbee/switch_cluster.c \
 	$(SRC_DIR)/zigbee/group_cluster.c \
 	$(SRC_DIR)/zigbee/general_commands.c \

--- a/src/stub/commands.c
+++ b/src/stub/commands.c
@@ -358,6 +358,31 @@ static int cmd_step_time(int argc, char **argv) {
     return 0;
 }
 
+static int cmd_set_counter(int argc, char **argv) {
+  if (argc != 3) {
+    fprintf(stderr, "Usage: set_counter <pin> <value>\n");
+    io_res_err("usage");
+    return -1;
+  }
+  char *e = NULL;
+  long pin = strtol(argv[1], &e, 10);
+  if (*argv[1] == '\0' || *e) {
+    fprintf(stderr, "Bad pin\n");
+    io_res_err("bad_pin=%s", argv[1]);
+    return -1;
+  }
+  long value = strtol(argv[2], &e, 10);
+  if (*argv[2] == '\0' || *e || value < 0) {
+    fprintf(stderr, "Bad counter value\n");
+    io_res_err("bad_value=%s", argv[2]);
+    return -1;
+  }
+  stub_set_pulse_counter((int)pin, (uint32_t)value);
+  printf("Set pulse counter on pin %ld to %ld\n", pin, value);
+  io_res_ok("pin=%ld value=%ld", pin, value);
+  return 0;
+}
+
 static int cmd_set_battery_voltage(int argc, char **argv) {
     if (argc != 2) {
         fprintf(stderr, "Usage: set_battery_voltage <millivolts>\n");
@@ -379,6 +404,22 @@ static int cmd_set_battery_voltage(int argc, char **argv) {
 
 /* Command table */
 static const SimpleReplCommand kCmds[] = {
+    { "machine",        cmd_machine        },
+    { "help",           cmd_help           },
+    { "s",              cmd_status         },
+    { "status",         cmd_status         },
+    { "net",            cmd_net            },
+    { "set_pin",        cmd_pin            },
+    { "read_pin",       cmd_read_pin       },
+    { "zcl_read",       cmd_zcl_read       },
+    { "zcl_write",      cmd_zcl_write      },
+    { "zcl_list_attrs", cmd_zcl_list_attrs },
+    { "zcl_cmd",        cmd_zcl_cmd        },
+    { "freeze_time",    cmd_freeze_time    },
+    { "step_time",      cmd_step_time      },
+    { "set_counter",    cmd_set_counter    },
+    { "q",              cmd_quit           },
+    { "quit",           cmd_quit           },
     { "machine",             cmd_machine             },
     { "help",                cmd_help                },
     { "s",                   cmd_status              },

--- a/src/stub/hal/gpio.c
+++ b/src/stub/hal/gpio.c
@@ -178,3 +178,92 @@ void ensure_valid_output_pin(hal_gpio_pin_t gpio_pin) {
         exit(1);
     }
 }
+
+typedef struct {
+  uint8_t initialized;
+  uint32_t value;
+  hal_gpio_pin_t gpio_pin;
+  hal_gpio_counter_t *handle;
+} stub_gpio_counter_t;
+
+static stub_gpio_counter_t gpio_counter[2];
+
+
+hal_gpio_counter_t hal_gpio_counter_init(hal_gpio_pin_t gpio_pin,
+                                         hal_gpio_counter_edge_t edge,
+                                         hal_gpio_pull_t pull) {
+
+  for (int i = 0; i < 2; i++) {
+    if (!gpio_counter[i].initialized) {
+      gpio_counter[i].initialized = 1;
+      gpio_counter[i].value = 0;
+      gpio_counter[i].gpio_pin = gpio_pin;
+      gpio_counter[i].handle = (hal_gpio_counter_t *)(uintptr_t)i;
+      io_log("GPIO", "Initialized GPIO counter %d on pin %d", i, gpio_pin);
+      return (hal_gpio_counter_t)(uintptr_t)i;
+    }
+  }
+
+  return HAL_GPIO_COUNTER_INVALID;
+}
+
+uint32_t hal_gpio_counter_read(hal_gpio_counter_t counter) {
+  if (counter < 0 || counter >= 2 || !gpio_counter[counter].initialized) {
+    io_log("GPIO", "Error: Invalid GPIO counter %d read", counter);
+    return 0;
+  }
+
+  io_log("GPIO", "Read GPIO counter %d = %u", counter,
+         gpio_counter[counter].value);
+
+  for (int i = 0; i < 2; i++) {
+    if (gpio_counter[i].initialized && gpio_counter[i].handle == counter) {
+      return gpio_counter[i].value;
+    }
+  }
+
+  return 0;
+}
+
+void hal_gpio_counter_reset(hal_gpio_counter_t counter) {
+    if (counter < 0 || counter >= 2) {
+      return;
+    }
+
+  for (int i = 0; i < 2; i++) {
+    if (gpio_counter[i].initialized && gpio_counter[i].handle == counter) {
+      gpio_counter[i].value = 0;
+      break;
+    }
+  }
+}
+
+void hal_gpio_counter_deinit(hal_gpio_counter_t counter) {
+  if (counter < 0 || counter >= 2) {
+    return;
+  }
+  gpio_counter[counter].initialized = 0;
+  gpio_counter[counter].value = 0;
+  io_log("GPIO", "Deinitialized GPIO counter %d", counter);
+}
+
+void hal_gpio_counter_stop(hal_gpio_counter_t counter) {
+  // No-op in stub
+}
+
+void hal_gpio_counter_start(hal_gpio_counter_t counter) {
+  // No-op in stub
+}
+
+void stub_set_pulse_counter(hal_gpio_pin_t gpio_pin, uint32_t value) {
+  io_log("GPIO", "Stub: set pulse counter on pin %d to %u", gpio_pin, value);
+
+  for (int i = 0; i < 2; i++) {
+    if (gpio_counter[i].initialized && gpio_counter[i].gpio_pin == gpio_pin) {
+      gpio_counter[i].value = value;
+      return;
+    }
+  }
+
+  io_log("GPIO", "Stub: no pulse counter found on pin %d to set value", gpio_pin);
+}

--- a/src/stub/hal/stub.h
+++ b/src/stub/hal/stub.h
@@ -10,6 +10,9 @@ void stub_gpio_enable_debug(int enable);
 void stub_gpio_simulate_input(hal_gpio_pin_t gpio_pin, uint8_t value);
 uint8_t stub_gpio_get_output(hal_gpio_pin_t gpio_pin);
 
+// GPIO counter stub functions
+void stub_set_pulse_counter(hal_gpio_pin_t gpio_pin, uint32_t value);
+
 // Tasks stub functions
 void stub_tasks_poll(void);
 

--- a/src/stub/stub_app.c
+++ b/src/stub/stub_app.c
@@ -101,6 +101,7 @@ void stub_app_print_help(void) {
          "bytes)");
     puts("  freeze_time <0|1>                     - Freeze/unfreeze time");
     puts("  step_time <ms>                        - Advance time by ms");
+    puts("  set_counter <pin> <value>             - Set pulse counter value");
     puts("  q, quit                               - Exit");
 }
 

--- a/src/telink/Makefile
+++ b/src/telink/Makefile
@@ -130,6 +130,7 @@ TELINK_SOURCES := \
 	hal/tasks.c \
 	hal/gpio.c \
 	hal/gpio_interrupts.c \
+	hal/gpio_counter.c \
 	hal/nvm.c \
 	hal/zigbee.c \
 	hal/zigbee_network.c \
@@ -150,6 +151,7 @@ COMMON_SOURCES := \
 	$(SRC_DIR)/base_components/led.c \
 	$(SRC_DIR)/base_components/network_indicator.c \
 	$(SRC_DIR)/base_components/relay.c \
+	$(SRC_DIR)/base_components/metering_bl0937.c \
 	$(SRC_DIR)/base_components/battery.c \
 	$(SRC_DIR)/device_config/config_nv.c \
 	$(SRC_DIR)/device_config/device_params_nv.c \
@@ -160,6 +162,7 @@ COMMON_SOURCES := \
 	$(SRC_DIR)/zigbee/general_commands.c \
 	$(SRC_DIR)/zigbee/group_cluster.c \
 	$(SRC_DIR)/zigbee/relay_cluster.c \
+	$(SRC_DIR)/zigbee/metering_cluster.c \
 	$(SRC_DIR)/zigbee/switch_cluster.c \
 	$(SRC_DIR)/zigbee/cover_switch_cluster.c \
 	$(SRC_DIR)/zigbee/cover_cluster.c \

--- a/src/telink/hal/gpio.c
+++ b/src/telink/hal/gpio.c
@@ -34,7 +34,7 @@ static gpio_config_t *find_gpio_config(hal_gpio_pin_t pin) {
 }
 
 // Convert HAL pull type to Telink pull type
-static GPIO_PullTypeDef hal_to_telink_pull(hal_gpio_pull_t pull) {
+GPIO_PullTypeDef hal_to_telink_pull(hal_gpio_pull_t pull) {
     switch (pull) {
     case HAL_GPIO_PULL_NONE:
         return PM_PIN_UP_DOWN_FLOAT;

--- a/src/telink/hal/gpio_counter.c
+++ b/src/telink/hal/gpio_counter.c
@@ -1,0 +1,172 @@
+#pragma pack(push, 1)
+#include "tl_common.h"
+#pragma pack(pop)
+
+#include "hal/gpio.h"
+#include <stdint.h>
+
+extern GPIO_PullTypeDef hal_to_telink_pull(hal_gpio_pull_t pull);
+
+// Maximum number of hardware counters available (TIMER0 and TIMER1)
+#define MAX_GPIO_COUNTERS    2
+
+typedef struct {
+    hal_gpio_pin_t gpio_pin;
+    uint8_t        timer_idx;
+    uint8_t        in_use;
+} gpio_counter_state_t;
+
+static gpio_counter_state_t counter_state[MAX_GPIO_COUNTERS];
+static uint8_t counters_initialized = 0;
+
+static void init_counter_state(void) {
+    if (!counters_initialized) {
+        for (int i = 0; i < MAX_GPIO_COUNTERS; i++) {
+            counter_state[i].gpio_pin  = HAL_INVALID_PIN;
+            counter_state[i].timer_idx = i; // TIMER0=0, TIMER1=1
+            counter_state[i].in_use    = 0;
+        }
+        counters_initialized = 1;
+    }
+}
+
+hal_gpio_counter_t hal_gpio_counter_init(hal_gpio_pin_t gpio_pin,
+                                         hal_gpio_counter_edge_t edge,
+                                         hal_gpio_pull_t pull) {
+    init_counter_state();
+
+    // Find a free counter slot
+    gpio_counter_state_t *slot   = NULL;
+    hal_gpio_counter_t    handle = HAL_GPIO_COUNTER_INVALID;
+
+    for (int i = 0; i < MAX_GPIO_COUNTERS; i++) {
+        if (!counter_state[i].in_use) {
+            slot   = &counter_state[i];
+            handle = i;
+            break;
+        }
+    }
+
+    if (slot == NULL) {
+        return HAL_GPIO_COUNTER_INVALID;
+    }
+
+    // Map HAL edge to Telink polarity
+    GPIO_PolTypeDef pol        = (edge == HAL_GPIO_COUNTER_RISING) ? POL_RISING : POL_FALLING;
+    GPIO_PinTypeDef telink_pin = (GPIO_PinTypeDef)gpio_pin;
+
+    // Configure GPIO for timer trigger mode
+    timer_gpio_init(slot->timer_idx, telink_pin, pol);
+
+    // Enable GPIO interrupt for the selected timer
+    if (slot->timer_idx == 0) {
+        drv_gpio_irq_risc0_en(telink_pin);
+    } else if (slot->timer_idx == 1) {
+        drv_gpio_irq_risc1_en(telink_pin);
+    }
+
+    // Set pull resistor
+    gpio_setup_up_down_resistor(telink_pin, hal_to_telink_pull(pull));
+
+    // Set timer to GPIO trigger (counter) mode
+    timer_set_mode(slot->timer_idx, TIMER_MODE_GPIO_TRIGGER);
+
+    // Reset counter to 0
+    timer_set_init_tick(slot->timer_idx, 0);
+
+    // Set max count value
+    timer_set_cap_tick(slot->timer_idx, 0xFFFFFFFF);
+
+    // Enable timer interrupt (needed for counter operation)
+    timer_irq_enable(slot->timer_idx);
+
+    // Start the timer/counter
+    timer_start(slot->timer_idx);
+
+    // Mark slot as in use
+    slot->gpio_pin = gpio_pin;
+    slot->in_use   = 1;
+
+    return handle;
+}
+
+void hal_gpio_counter_deinit(hal_gpio_counter_t counter) {
+    if (counter < 0 || counter >= MAX_GPIO_COUNTERS) {
+        return;
+    }
+
+    gpio_counter_state_t *slot = &counter_state[counter];
+    if (!slot->in_use) {
+        return;
+    }
+
+    // Stop the timer/counter
+    hal_gpio_counter_stop(counter);
+
+    // Reset the counter
+    hal_gpio_counter_reset(counter);
+
+    // Disable GPIO interrupt for the selected timer
+    GPIO_PinTypeDef telink_pin = (GPIO_PinTypeDef)slot->gpio_pin;
+    if (slot->timer_idx == 0) {
+        drv_gpio_irq_risc0_dis(telink_pin);
+    } else if (slot->timer_idx == 1) {
+        drv_gpio_irq_risc1_dis(telink_pin);
+    }
+
+    // Reset slot state
+    slot->gpio_pin = HAL_INVALID_PIN;
+    slot->in_use   = 0;
+}
+
+uint32_t hal_gpio_counter_read(hal_gpio_counter_t counter) {
+    if (counter < 0 || counter >= MAX_GPIO_COUNTERS) {
+        return 0;
+    }
+
+    gpio_counter_state_t *slot = &counter_state[counter];
+    if (!slot->in_use) {
+        return 0;
+    }
+
+    return reg_tmr_tick(slot->timer_idx);
+}
+
+void hal_gpio_counter_reset(hal_gpio_counter_t counter) {
+    if (counter < 0 || counter >= MAX_GPIO_COUNTERS) {
+        return;
+    }
+
+    gpio_counter_state_t *slot = &counter_state[counter];
+    if (!slot->in_use) {
+        return;
+    }
+
+    timer_set_init_tick(slot->timer_idx, 0);
+}
+
+void hal_gpio_counter_start(hal_gpio_counter_t counter) {
+    if (counter < 0 || counter >= MAX_GPIO_COUNTERS) {
+        return;
+    }
+
+    gpio_counter_state_t *slot = &counter_state[counter];
+    if (!slot->in_use) {
+        return;
+    }
+
+    timer_start(slot->timer_idx);
+}
+
+void hal_gpio_counter_stop(hal_gpio_counter_t counter) {
+    if (counter < 0 || counter >= MAX_GPIO_COUNTERS) {
+        return;
+    }
+
+    gpio_counter_state_t *slot = &counter_state[counter];
+    if (!slot->in_use) {
+        return;
+    }
+
+    timer_stop(slot->timer_idx);
+}

--- a/src/telink/hal/zigbee_zcl.c
+++ b/src/telink/hal/zigbee_zcl.c
@@ -27,6 +27,29 @@ static uint8_t hal_endpoints_cnt          = 0;
 static hal_attribute_change_callback_t attribute_change_callback = NULL;
 static hal_zcl_activity_callback_t     zcl_activity_callback     = NULL;
 
+// The Telink SDK compiles zcl_electrical_measurement.c and zcl_metering.c, so
+// their attribute machinery is available, but the SDK's own *_register()
+// prototypes are gated behind ZCL_ELECTRICAL_MEASUREMENT / ZCL_METERING (not
+// defined in app_cfg.h, to keep the SE/measurement command handling out).
+// Register both clusters through the generic zcl_registerCluster() instead --
+// the same mechanism the custom cluster wrappers (zcl_multistate_input,
+// zcl_cover_switch_config) already use. These are attribute-only servers, so no
+// cluster-specific command handler and no app callback are needed (both NULL).
+static status_t electrical_measurement_register(u8 endpoint, u16 manuCode,
+                                                u8 attrNum,
+                                                const zclAttrInfo_t attrTbl[],
+                                                cluster_forAppCb_t cb) {
+    return zcl_registerCluster(endpoint, ZCL_CLUSTER_ELECTRICAL_MEASUREMENT,
+                               manuCode, attrNum, attrTbl, NULL, NULL);
+}
+
+static status_t metering_register(u8 endpoint, u16 manuCode, u8 attrNum,
+                                  const zclAttrInfo_t attrTbl[],
+                                  cluster_forAppCb_t cb) {
+    return zcl_registerCluster(endpoint, ZCL_CLUSTER_METERING, manuCode, attrNum,
+                               attrTbl, NULL, NULL);
+}
+
 static cluster_registerFunc_t get_register_func_by_cluster_id(u16 cluster_id) {
     if (cluster_id == ZCL_CLUSTER_GEN_BASIC) {
         return zcl_basic_register;
@@ -61,6 +84,12 @@ static cluster_registerFunc_t get_register_func_by_cluster_id(u16 cluster_id) {
     }
     if (cluster_id == ZCL_CLUSTER_GEN_POLL_CONTROL) {
         return zcl_pollCtrl_register;
+    }
+    if (cluster_id == ZCL_CLUSTER_ELECTRICAL_MEASUREMENT) {
+        return electrical_measurement_register;
+    }
+    if (cluster_id == ZCL_CLUSTER_METERING) {
+        return metering_register;
     }
     return NULL;
 }

--- a/src/zigbee/consts.h
+++ b/src/zigbee/consts.h
@@ -15,7 +15,30 @@
 #define ZCL_CLUSTER_GROUPS                    0x0004
 #define ZCL_CLUSTER_OTA_BOOTLOAD              0x0019
 #define ZCL_CLUSTER_WINDOW_COVERING           0x0102
+#define ZCL_CLUSTER_METERING                  0x0702
+#define ZCL_CLUSTER_ELECTRICAL_MEASUREMENT    0x0B04
 #define ZCL_CLUSTER_COVER_SWITCH_CONFIG       0xFC01
+
+// Electrical Measurement (0x0B04) attributes
+#define ZCL_ATTR_EM_MEASUREMENT_TYPE          0x0000
+#define ZCL_ATTR_EM_RMS_VOLTAGE               0x0505
+#define ZCL_ATTR_EM_RMS_CURRENT               0x0508
+#define ZCL_ATTR_EM_ACTIVE_POWER              0x050B
+#define ZCL_ATTR_EM_AC_VOLTAGE_MULT           0x0600
+#define ZCL_ATTR_EM_AC_VOLTAGE_DIV            0x0601
+#define ZCL_ATTR_EM_AC_CURRENT_MULT           0x0602
+#define ZCL_ATTR_EM_AC_CURRENT_DIV            0x0603
+#define ZCL_ATTR_EM_AC_POWER_MULT             0x0604
+#define ZCL_ATTR_EM_AC_POWER_DIV              0x0605
+
+// Metering (0x0702) attributes
+#define ZCL_ATTR_METERING_CURR_SUMM_DELIVERED 0x0000
+#define ZCL_ATTR_METERING_STATUS              0x0200
+#define ZCL_ATTR_METERING_UNIT_OF_MEASURE     0x0300
+#define ZCL_ATTR_METERING_MULTIPLIER          0x0301
+#define ZCL_ATTR_METERING_DIVISOR             0x0302
+#define ZCL_ATTR_METERING_SUMM_FORMATTING     0x0303
+#define ZCL_ATTR_METERING_DEVICE_TYPE         0x0306
 
 
 // Attributes

--- a/src/zigbee/metering_cluster.c
+++ b/src/zigbee/metering_cluster.c
@@ -1,0 +1,153 @@
+#include "metering_cluster.h"
+
+#include <string.h>
+
+#include "cluster_common.h"
+#include "consts.h"
+#include "hal/printf_selector.h"
+
+static void metering_cluster_on_driver_update(void *param);
+
+static void set_uint48(uint8_t out[6], uint64_t value) {
+    for (int i = 0; i < 6; i++) {
+        out[i] = (uint8_t)(value >> (8 * i));
+    }
+}
+
+void metering_cluster_add_to_endpoint(zigbee_metering_cluster *cluster,
+                                      hal_zigbee_endpoint *endpoint) {
+    cluster->endpoint = endpoint->endpoint;
+
+    // --- Electrical Measurement (0x0B04) ---
+    cluster->measurement_type = 1; // bit0: active measurement (AC)
+    cluster->ac_voltage_mult  = 1;
+    cluster->ac_voltage_div   = 10;   // raw is deciVolt
+    cluster->ac_current_mult  = 1;
+    cluster->ac_current_div   = 1000; // raw is mA
+    cluster->ac_power_mult    = 1;
+    cluster->ac_power_div     = 10;   // raw is deciWatt
+
+    {
+        hal_zigbee_attribute *table = cluster->em_attr_infos;
+        SETUP_ATTR_FOR_TABLE(table, 0, ZCL_ATTR_EM_MEASUREMENT_TYPE,
+                             ZCL_DATA_TYPE_BITMAP32, ATTR_READONLY,
+                             cluster->measurement_type);
+        SETUP_ATTR_FOR_TABLE(table, 1, ZCL_ATTR_EM_RMS_VOLTAGE,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->metering->voltage_dv);
+        SETUP_ATTR_FOR_TABLE(table, 2, ZCL_ATTR_EM_RMS_CURRENT,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->metering->current_ma);
+        SETUP_ATTR_FOR_TABLE(table, 3, ZCL_ATTR_EM_ACTIVE_POWER,
+                             ZCL_DATA_TYPE_INT16, ATTR_READONLY,
+                             cluster->metering->power_dw);
+        SETUP_ATTR_FOR_TABLE(table, 4, ZCL_ATTR_EM_AC_VOLTAGE_MULT,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->ac_voltage_mult);
+        SETUP_ATTR_FOR_TABLE(table, 5, ZCL_ATTR_EM_AC_VOLTAGE_DIV,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->ac_voltage_div);
+        SETUP_ATTR_FOR_TABLE(table, 6, ZCL_ATTR_EM_AC_CURRENT_MULT,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->ac_current_mult);
+        SETUP_ATTR_FOR_TABLE(table, 7, ZCL_ATTR_EM_AC_CURRENT_DIV,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->ac_current_div);
+        SETUP_ATTR_FOR_TABLE(table, 8, ZCL_ATTR_EM_AC_POWER_MULT,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->ac_power_mult);
+        SETUP_ATTR_FOR_TABLE(table, 9, ZCL_ATTR_EM_AC_POWER_DIV,
+                             ZCL_DATA_TYPE_UINT16, ATTR_READONLY,
+                             cluster->ac_power_div);
+    }
+
+    endpoint->clusters[endpoint->cluster_count].cluster_id =
+        ZCL_CLUSTER_ELECTRICAL_MEASUREMENT;
+    endpoint->clusters[endpoint->cluster_count].attribute_count = 10;
+    endpoint->clusters[endpoint->cluster_count].attributes =
+        cluster->em_attr_infos;
+    endpoint->clusters[endpoint->cluster_count].is_server    = 1;
+    endpoint->clusters[endpoint->cluster_count].cmd_callback = NULL;
+    endpoint->cluster_count++;
+
+    // --- Metering (0x0702) ---
+    set_uint48(cluster->curr_summ_delivered, cluster->metering->energy_wh);
+    cluster->status               = 0;    // bitmap8, no error
+    cluster->unit_of_measure      = 0;    // kWh
+    cluster->multiplier           = 1;    // uint24
+    cluster->divisor              = 1000; // Wh -> kWh
+    cluster->summation_formatting = 0x2B; // 3 decimals, suppress zeros
+    cluster->metering_device_type = 0;    // electric metering
+
+    {
+        hal_zigbee_attribute *table = cluster->mt_attr_infos;
+        SETUP_ATTR_FOR_TABLE(table, 0, ZCL_ATTR_METERING_CURR_SUMM_DELIVERED,
+                             ZCL_DATA_TYPE_UINT48, ATTR_READONLY,
+                             cluster->curr_summ_delivered);
+        SETUP_ATTR_FOR_TABLE(table, 1, ZCL_ATTR_METERING_STATUS,
+                             ZCL_DATA_TYPE_BITMAP8, ATTR_READONLY,
+                             cluster->status);
+        SETUP_ATTR_FOR_TABLE(table, 2, ZCL_ATTR_METERING_UNIT_OF_MEASURE,
+                             ZCL_DATA_TYPE_ENUM8, ATTR_READONLY,
+                             cluster->unit_of_measure);
+        SETUP_ATTR_FOR_TABLE(table, 3, ZCL_ATTR_METERING_MULTIPLIER,
+                             ZCL_DATA_TYPE_UINT24, ATTR_READONLY,
+                             cluster->multiplier);
+        SETUP_ATTR_FOR_TABLE(table, 4, ZCL_ATTR_METERING_DIVISOR,
+                             ZCL_DATA_TYPE_UINT24, ATTR_READONLY,
+                             cluster->divisor);
+        SETUP_ATTR_FOR_TABLE(table, 5, ZCL_ATTR_METERING_SUMM_FORMATTING,
+                             ZCL_DATA_TYPE_BITMAP8, ATTR_READONLY,
+                             cluster->summation_formatting);
+        SETUP_ATTR_FOR_TABLE(table, 6, ZCL_ATTR_METERING_DEVICE_TYPE,
+                             ZCL_DATA_TYPE_BITMAP8, ATTR_READONLY,
+                             cluster->metering_device_type);
+    }
+    // uint24 attributes: ZCL wire size is 3 bytes, storage is uint32
+    cluster->mt_attr_infos[3].size = 3;
+    cluster->mt_attr_infos[4].size = 3;
+
+    endpoint->clusters[endpoint->cluster_count].cluster_id =
+        ZCL_CLUSTER_METERING;
+    endpoint->clusters[endpoint->cluster_count].attribute_count = 7;
+    endpoint->clusters[endpoint->cluster_count].attributes =
+        cluster->mt_attr_infos;
+    endpoint->clusters[endpoint->cluster_count].is_server    = 1;
+    endpoint->clusters[endpoint->cluster_count].cmd_callback = NULL;
+    endpoint->cluster_count++;
+
+    // Hook driver updates -> attribute change notifications
+    cluster->metering->on_update      = metering_cluster_on_driver_update;
+    cluster->metering->callback_param = cluster;
+}
+
+static void metering_cluster_on_driver_update(void *param) {
+    zigbee_metering_cluster *cluster = (zigbee_metering_cluster *)param;
+    metering_bl0937_t *      m       = cluster->metering;
+
+    if (m->voltage_dv != cluster->last_voltage_dv) {
+        cluster->last_voltage_dv = m->voltage_dv;
+        hal_zigbee_notify_attribute_changed(cluster->endpoint,
+                                            ZCL_CLUSTER_ELECTRICAL_MEASUREMENT,
+                                            ZCL_ATTR_EM_RMS_VOLTAGE);
+    }
+    if (m->current_ma != cluster->last_current_ma) {
+        cluster->last_current_ma = m->current_ma;
+        hal_zigbee_notify_attribute_changed(cluster->endpoint,
+                                            ZCL_CLUSTER_ELECTRICAL_MEASUREMENT,
+                                            ZCL_ATTR_EM_RMS_CURRENT);
+    }
+    if (m->power_dw != cluster->last_power_dw) {
+        cluster->last_power_dw = m->power_dw;
+        hal_zigbee_notify_attribute_changed(cluster->endpoint,
+                                            ZCL_CLUSTER_ELECTRICAL_MEASUREMENT,
+                                            ZCL_ATTR_EM_ACTIVE_POWER);
+    }
+    if (m->energy_wh != cluster->last_energy_wh) {
+        cluster->last_energy_wh = m->energy_wh;
+        set_uint48(cluster->curr_summ_delivered, m->energy_wh);
+        hal_zigbee_notify_attribute_changed(cluster->endpoint,
+                                            ZCL_CLUSTER_METERING,
+                                            ZCL_ATTR_METERING_CURR_SUMM_DELIVERED);
+    }
+}

--- a/src/zigbee/metering_cluster.h
+++ b/src/zigbee/metering_cluster.h
@@ -1,0 +1,57 @@
+#ifndef _METERING_CLUSTER_H_
+#define _METERING_CLUSTER_H_
+
+#include <stdint.h>
+
+#include "base_components/metering_bl0937.h"
+#include "hal/zigbee.h"
+
+/*
+ * Exposes BL0937 measurements through two standard ZCL server clusters:
+ *   - Electrical Measurement (0x0B04): rmsVoltage / rmsCurrent / activePower
+ *     with the AC formatting divisors set so values decode as
+ *     V = raw/10, A = raw/1000, W = raw/10.
+ *   - Metering (0x0702): currentSummationDelivered as uint48 in Wh with
+ *     divisor 1000 (=> kWh in Z2M).
+ *
+ * Attribute values are refreshed and change-notified from the driver's
+ * on_update callback; the coordinator's configured ZCL reporting then
+ * takes care of pushing them out.
+ */
+
+typedef struct {
+    uint8_t              endpoint;
+    metering_bl0937_t *  metering;
+
+    // Electrical Measurement cluster storage
+    uint32_t             measurement_type;    // bitmap32, bit0 = AC active
+    uint16_t             ac_voltage_mult, ac_voltage_div;
+    uint16_t             ac_current_mult, ac_current_div;
+    uint16_t             ac_power_mult, ac_power_div;
+    hal_zigbee_attribute em_attr_infos[10];
+
+    // Metering cluster storage
+    uint8_t              curr_summ_delivered[6]; // uint48, little endian, Wh
+    uint8_t              status;                 // bitmap8, 0 = no error
+    uint8_t              unit_of_measure;        // 0 = kWh
+    uint32_t             multiplier;             // uint24 (stored low 3 bytes)
+    uint32_t             divisor;                // uint24 (stored low 3 bytes)
+    uint8_t              summation_formatting;
+    uint8_t              metering_device_type;   // 0 = electric metering
+    hal_zigbee_attribute mt_attr_infos[7];
+
+    // Last reported values (for change-only notifications)
+    uint16_t             last_voltage_dv;
+    uint16_t             last_current_ma;
+    int16_t              last_power_dw;
+    uint32_t             last_energy_wh;
+} zigbee_metering_cluster;
+
+/**
+ * Register both measurement clusters on the given endpoint and hook the
+ * driver's update callback. Adds 2 entries to endpoint->clusters.
+ */
+void metering_cluster_add_to_endpoint(zigbee_metering_cluster *cluster,
+                                      hal_zigbee_endpoint *endpoint);
+
+#endif


### PR DESCRIPTION
## What

Adds optional power/energy metering for BL0937-based Tuya plugs (a very common metering chip on TS011F and similar devices). Generic feature only — no specific board is enabled here (see the follow-up PR for the Aubess PM).

## How it works

- **New `E` config-str token** for the pin wiring: `E<CF><CF1><SEL>[i]` (2-char pin names; trailing `i` inverts the SEL level). Parsed in `config_parser`, mirrors the existing token style.
- **BL0937 driver** (`base_components/metering_bl0937.c`): counts CF/CF1 pulses via a small GPIO hardware-counter HAL (`gpio_counter`), multiplexes CF1 between voltage and current with SEL, and produces rmsVoltage / rmsCurrent / activePower / accumulated energy.
- **ZCL clusters** (`zigbee/metering_cluster.c`): serves Electrical Measurement (`0x0B04`: rmsVoltage/Current/activePower + AC multiplier/divisor incl. `acPowerMultiplier 0x0604`) and Metering (`0x0702`: currentSummationDelivered, Status `0x0200`, unit/multiplier/divisor/formatting/deviceType).
- **HAL fix** (`telink/hal/zigbee_zcl.c`): `get_register_func_by_cluster_id()` now maps `0x0B04`/`0x0702` to a register function (via the generic `zcl_registerCluster()`). Without this the clusters are advertised in the simple descriptor but every attribute read returns `UNSUPPORTED_ATTRIBUTE` and no reports are emitted.
- **Z2M converter**: the generator emits `electricityMeter({ endpointNames: [...] })` for metering devices, so the exposed properties carry the endpoint suffix and match the reported data on multi-endpoint devices (otherwise HA discovers `power`/`current` entities that never receive data while the values land under `power_switch`/`current_switch`).

## Notes

- TC32 build fixes needed by the driver: 32-bit-only frequency math (the toolchain has no 64-bit division helpers) and `stddef.h` for `NULL`.
- Calibration coefficients (`DEFAULT_COEF_*`) are **placeholder defaults** and need per-board calibration — a concrete calibrated board is added in the follow-up PR.
- Out of scope: overcurrent protection and a flash/OEM scanner tool (kept on separate branches).

## Testing

- Host stub build compiles; clusters register with their full attribute tables.
- Firmware build (Telink TLSR8258) passes.
- Exercised end-to-end on hardware in the follow-up (Aubess PM) PR.